### PR TITLE
Scale poop icon with progress

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,7 +15,9 @@ const ownedAPoopers = new Array(aPoopers.length).fill(0);
 
 // ─── Element refs ────────────────────────────────────
 const poopAmount         = document.getElementById("poopAmount");
-const poopIcon           = document.getElementsByClassName("poopIcon");
+const poopIcon           = document.querySelector(".poopIcon");
+const basePoopIconSize   = parseFloat(getComputedStyle(poopIcon).fontSize);
+const maxPoopForIconSize = 300000; // cap growth at 300k poop
 const defecateButton     = document.getElementById("defecatebutton");
 const spacesDisplay      = document.getElementById("spaces");
 const aPooperCostDisplay = document.getElementById("aPooperCost");
@@ -219,7 +221,10 @@ function updateUI() {
   const pps = getPoopPerSecond();
   document.getElementById('poopPerSecond').textContent =
     `Poop/sec: ${formatNumber(pps)}`;
-  //poopIcon.style.fontSize = `${32 + points/100}px`;//
+  // Grow the poop icon up to 10× its base size at 300k poop
+  const growthProgress = Math.min(points, maxPoopForIconSize) / maxPoopForIconSize;
+  const newIconSize = basePoopIconSize * (1 + growthProgress * 9);
+  poopIcon.style.fontSize = `${newIconSize}px`;
   getUnlockedSpaces();
   const slots = document.querySelectorAll('#spaces-grid .space-item');
   slots.forEach((slot, i) => {

--- a/style.css
+++ b/style.css
@@ -111,8 +111,9 @@ button:hover {
   gap: 1rem;
   padding: 0.5rem 1rem;
 }
-.poop-icon {
+.poopIcon {
   font-size: 2rem;
+  margin-right: 10px;
 }
 #poopAmount {
   font-size: 1.5rem;
@@ -121,10 +122,6 @@ button:hover {
   grid-area: main;
   padding: 1rem;
   overflow: auto;
-}
-#poopIcon {
-  font-size: 32px;
-  margin-right: 10px;
 }
 /* side panels */
 #poop-side-panel {


### PR DESCRIPTION
## Summary
- Grow the poop icon as poop points increase, up to 10× size at 300k poop
- Clean up CSS so `.poopIcon` has consistent base styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893c65af71c8326957c94f018ad30bf