### PR TITLE
Add upgrade rendering and purchasing

### DIFF
--- a/style.css
+++ b/style.css
@@ -167,7 +167,42 @@ button:hover {
   flex-direction: column;
   gap: 0.5rem;
   margin-bottom: 1rem;
-  } 
+  }
+
+.upgrade-card {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  background: #d9c7a1;
+  border: 2px solid #4e3629;
+  border-radius: 0.5rem;
+  text-align: left;
+}
+
+.upgrade-card.locked {
+  opacity: 0.6;
+}
+
+.upgrade-card.purchased {
+  opacity: 0.75;
+}
+
+.upgrade-card h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.upgrade-card p {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.upgrade-card button {
+  margin-top: 0.5rem;
+  align-self: stretch;
+}
 
 
 /* Spaces grid */


### PR DESCRIPTION
## Summary
- inline the upgrade definitions alongside the shared game state
- render upgrade cards that unlock, enable, and show purchase status based on requirements
- apply upgrade effects to game state, including passive income and cost tweaks, and style the cards

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb403225608326a862015fc401e65a