### PR TITLE
Fix poop side panel grid layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -126,14 +126,12 @@ button:hover {
 /* side panels */
 #poop-side-panel {
   grid-area: side;
-  grid-template-rows:
-  auto    /* poop progress bar (poop-header) */
-  auto     /* poop icon + amount (poop-info) */
-  1fr;     /* spaces grid + side panel */
+  display: grid;
+  grid-template-rows: auto auto 1fr;
   grid-template-areas:
-  "currencies""
-  "poopers""
-  "upgrades";
+    "currencies"
+    "poopers"
+    "upgrades";
   background: #b4a98d;
   padding: 1rem;
   overflow: auto;


### PR DESCRIPTION
## Summary
- correct the poop side panel grid definition so each section maps to its named area
- align the currency, pooper, and upgrade panels within the grid for consistent spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb403ed5708326b3561eb6c80854c2