### PR TITLE
Ensure initial space unlocked and refresh UI on load

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ const spaceThresholds = [20, 100, 1000, 100000, 1000000, 100000000, 1000000000, 
 const maxSpaces = spaceThresholds.length;
 let toilets =  new Array(maxSpaces).fill(null);
 let averagePooperCost = 10;
-let initialUnlocked = 0
+let initialUnlocked = 1
 const aPoopers = [
   { name: "Average Pooper", rate: 1 }  // rate = poop/sec
 ];
@@ -72,6 +72,8 @@ document.addEventListener('DOMContentLoaded', () => {
     item.appendChild(btn);
     spacesGrid.appendChild(item);
   }
+
+  updateUI();
 
   // 2) Clicking anywhere else hides the menu
   document.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- ensure at least one toilet slot is unlocked by default
- trigger an initial UI refresh after the spaces grid is generated so counters render immediately

## Testing
- python3 -m http.server 8000 (manual)
- playwright check of initial UI state

------
https://chatgpt.com/codex/tasks/task_e_68cb401a1b248326a0fed3f850af4e46