### PR TITLE
Refactor building spots and automate occupancy

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,10 +69,7 @@
     </section>
     
     <!-- Building menu (hidden by default) -->
-    <div id="building-menu" class="hidden">
-      <button data-building="toilet">Toilet</button>
-      <!-- later: <button data-building="gold-mine">Gold Mine</button>, etc -->
-    </div>
+    <div id="building-menu" class="hidden"></div>
   </div>
 </body>
 <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -229,6 +229,22 @@ button:hover {
   font-size: 0.75rem;
   cursor: pointer;
 }
+.spot-info {
+  font-size: 0.7rem;
+  text-align: center;
+  margin-bottom: 0.35rem;
+  line-height: 1.2;
+}
+
+.spot-info strong {
+  display: block;
+  font-size: 0.8rem;
+  margin-bottom: 0.1rem;
+}
+
+.spot-info div {
+  white-space: nowrap;
+}
 .space-item button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
@@ -258,6 +274,16 @@ button:hover {
   border-radius: 0.2rem;      /* slightly smaller corners */
   min-width: auto;
   background: #3d2e2e;
+}
+#building-menu button .spot-name {
+  font-weight: 600;
+  display: block;
+}
+
+#building-menu button .spot-stats {
+  font-size: 0.7rem;
+  opacity: 0.85;
+  line-height: 1.3;
 }
 #building-menu button:hover {
   background: #5a4444;


### PR DESCRIPTION
## Summary
- replace the single toilet slot model with configurable spot types that store capacity, occupants, and multiplier metadata
- refresh the building menu and slot UI so players buy spot types, see their stats, and automatically fill capacity without manual assignment
- add helper routines that let poopers request and release spot occupancy while applying the spot multiplier to their production

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cbf5911e5c8326914182c0e3638c9f