### PR TITLE
Refactor poop status layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,19 @@
       
       <!-- Poop Tab -->
       <div id="tab-poop" class="tab-panel">
-        
+
+        <div id="poop-status-bar">
+          <h2>poop:</h2>
+          <p class="poop"></p>
+          <div class="poopIcon">💩</div>
+          <div id="poopAmount">0</div>
+          <div id="poopPerSecond">poop/second: 0</div>
+        </div>
+
+        <div id="defecatebutton-wrapper">
+          <button id="defecatebutton">defecate</button>
+        </div>
+
         <!-- A.a: progress bar toward 10^15 -->
         <div class="poop-header">
           <div id="poop-progress-container">
@@ -32,16 +44,6 @@
           </div>
         </div>
 
-        <!-- poop main poop counter + defecate button -->
-        <div class="poop-info">
-          <h2>poop:</h2>
-          <p class="poop"></p>
-            <div class="poopIcon">💩</div>
-            <div id="poopAmount">0</div>
-            <div id="poopPerSecond">poop/second: 0</div>
-          <button id="defecatebutton">defecate</button>
-        </div>
-  
         <!-- main grid -->
         <div class="poop-main">
           <div id="spaces-grid">

--- a/style.css
+++ b/style.css
@@ -73,16 +73,79 @@ button:hover {
   display: grid;
   grid-template-columns: 1fr 300px;
   grid-template-rows:
+    auto     /* poop status bar */
+    auto     /* defecate button */
     auto     /* poop progress bar (poop-header) */
-    auto     /* poop icon + amount (poop-info) */
     1fr;     /* spaces grid + side panel */
   grid-template-areas:
+    "status status"
+    "button side"
     "header side"
-    "info   side"
     "main   side";
   gap: 0;
   overflow: visible;
 }
+
+#poop-status-bar {
+  grid-area: status;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #d9c7a1;
+  border-bottom: 2px solid #4e3629;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+#poop-status-bar h2 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+#poop-status-bar .poop,
+#poop-status-bar #poopAmount,
+#poop-status-bar #poopPerSecond {
+  margin: 0;
+  font-weight: 600;
+}
+
+#defecatebutton-wrapper {
+  grid-area: button;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  background: #f3e9d2;
+  border-bottom: 2px solid rgba(78, 54, 41, 0.2);
+}
+
+#defecatebutton {
+  padding: 0.9rem 2rem;
+  font-size: 1rem;
+  border-radius: 9999px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+@media (max-width: 640px) {
+  #poop-status-bar {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+    gap: 0.5rem;
+  }
+
+  #poop-status-bar > * {
+    width: 100%;
+  }
+}
+
 .poop-header {
   grid-area: header;
   padding: 1rem;
@@ -99,17 +162,6 @@ button:hover {
   width: 0%;
   background: #4caf50;
   transition: width 0.3s ease;
-}
-/* main + sidebar */
-/* Poop info */
-.poop-info {
-  grid-area: info;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-  padding: 0.5rem 1rem;
 }
 .poopIcon {
   font-size: 2rem;


### PR DESCRIPTION
## Summary
- wrap the poop metrics in a new sticky #poop-status-bar container
- add a dedicated flex wrapper for the defecate button and refreshed button styling
- ensure existing script selectors continue to target the moved poop stats elements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cca7f61d288326acf5a872f8f2ef0f