### PR TITLE
Improve mobile poop controls sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -108,15 +108,38 @@ button:hover {
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  text-align: center;
   gap: 1rem;
-  padding: 0.5rem 1rem;
+  padding: 1.25rem 1.5rem;
+  width: min(100%, 420px);
+  margin: 0 auto;
 }
 .poopIcon {
-  font-size: 2rem;
-  margin-right: 10px;
+  font-size: clamp(3rem, 8vw, 4.5rem);
+  line-height: 1;
+  min-height: 3.5rem;
 }
 #poopAmount {
-  font-size: 1.5rem;
+  font-size: clamp(2.25rem, 7vw, 3.5rem);
+  font-weight: 700;
+}
+#poopPerSecond {
+  font-size: clamp(1.15rem, 4.5vw, 1.75rem);
+}
+#defecatebutton {
+  font-size: clamp(1.2rem, 4.5vw, 1.6rem);
+  padding: 0.9rem 1.75rem;
+  min-height: 3.25rem;
+  width: 100%;
+  max-width: 360px;
+  border-radius: 999px;
+  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.15);
+}
+@media (min-width: 768px) {
+  #defecatebutton {
+    width: auto;
+    min-width: 260px;
+  }
 }
 .poop-main {
   grid-area: main;


### PR DESCRIPTION
## Summary
- enlarge the poop icon, poop amount, and poop-per-second display for better legibility
- expand and round the Defecate button with responsive sizing so it stays thumb-friendly on phones
- center the poop info stack with wider padding to keep the layout balanced on desktop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccaa13628083268601662173aaa443