### PR TITLE
Add mobile tab layout for poop side panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,20 +52,74 @@
           <div id="currencies-panel">
             <!-- resource icons + amounts -->
           </div>
-          <div id="poopers-panel">
-            <div id="pooper-hiring" class="panel-section">
-              <h3 class="panel-heading">Pooper Hiring</h3>
-              <!-- list of pooper types + available/total + buy button -->
-            </div>
-            <section id="pooper-list-section" class="panel-section">
-              <h3 class="panel-heading">Pooper List</h3>
-              <div id="pooper-list-body" class="pooper-list" role="list">
-                <!-- dynamically populated -->
+          <nav id="poop-mobile-tabs" role="tablist" aria-label="Poop management panels">
+            <button
+              type="button"
+              class="poop-mobile-tab active"
+              data-target="pooper-hiring"
+              role="tab"
+              id="poop-mobile-tab-hiring"
+              aria-controls="pooper-hiring"
+              aria-selected="true"
+            >
+              Hiring
+            </button>
+            <button
+              type="button"
+              class="poop-mobile-tab"
+              data-target="pooper-list-section"
+              role="tab"
+              id="poop-mobile-tab-list"
+              aria-controls="pooper-list-section"
+              aria-selected="false"
+            >
+              Pooper List
+            </button>
+            <button
+              type="button"
+              class="poop-mobile-tab"
+              data-target="upgrades-panel"
+              role="tab"
+              id="poop-mobile-tab-upgrades"
+              aria-controls="upgrades-panel"
+              aria-selected="false"
+            >
+              Upgrades
+            </button>
+          </nav>
+          <div id="poop-mobile-panels">
+            <div id="poopers-panel">
+              <div
+                id="pooper-hiring"
+                class="panel-section mobile-panel-active"
+                data-mobile-panel
+                role="tabpanel"
+                aria-labelledby="poop-mobile-tab-hiring"
+              >
+                <h3 class="panel-heading">Pooper Hiring</h3>
+                <!-- list of pooper types + available/total + buy button -->
               </div>
-            </section>
-          </div>
-          <div id="upgrades-panel">
-            <!-- upgrade icons (locked until milestones) -->
+              <section
+                id="pooper-list-section"
+                class="panel-section"
+                data-mobile-panel
+                role="tabpanel"
+                aria-labelledby="poop-mobile-tab-list"
+              >
+                <h3 class="panel-heading">Pooper List</h3>
+                <div id="pooper-list-body" class="pooper-list" role="list">
+                  <!-- dynamically populated -->
+                </div>
+              </section>
+            </div>
+            <div
+              id="upgrades-panel"
+              data-mobile-panel
+              role="tabpanel"
+              aria-labelledby="poop-mobile-tab-upgrades"
+            >
+              <!-- upgrade icons (locked until milestones) -->
+            </div>
           </div>
         </aside>
       </div>

--- a/script.js
+++ b/script.js
@@ -257,6 +257,87 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  const mobileTabsContainer = document.getElementById('poop-mobile-tabs');
+  const mobilePanelIds = ['pooper-hiring', 'pooper-list-section', 'upgrades-panel'];
+  const mobilePanels = mobilePanelIds
+    .map((panelId) => document.getElementById(panelId))
+    .filter((panel) => panel);
+
+  if (mobileTabsContainer && mobilePanels.length) {
+    const mobileTabButtons = Array.from(
+      mobileTabsContainer.querySelectorAll('.poop-mobile-tab[data-target]')
+    );
+    const mobileMediaQuery = window.matchMedia('(max-width: 767px)');
+
+    function showAllMobilePanels() {
+      mobilePanels.forEach((panel) => {
+        panel.classList.remove('mobile-panel-active');
+        panel.removeAttribute('aria-hidden');
+        panel.removeAttribute('hidden');
+        panel.removeAttribute('tabindex');
+      });
+      mobileTabButtons.forEach((button) => {
+        button.classList.remove('active');
+        button.setAttribute('aria-selected', 'false');
+      });
+    }
+
+    function activateMobilePanel(targetId) {
+      mobilePanels.forEach((panel) => {
+        const isActive = panel.id === targetId;
+        panel.classList.toggle('mobile-panel-active', isActive);
+        panel.toggleAttribute('hidden', !isActive);
+        panel.setAttribute('aria-hidden', String(!isActive));
+        panel.setAttribute('tabindex', isActive ? '0' : '-1');
+      });
+
+      mobileTabButtons.forEach((button) => {
+        const isActive = button.dataset.target === targetId;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-selected', String(isActive));
+      });
+    }
+
+    function syncMobilePanelsForViewport() {
+      if (!mobileMediaQuery.matches) {
+        showAllMobilePanels();
+        return;
+      }
+
+      let activeButton = mobileTabButtons.find((button) => button.classList.contains('active'));
+      if (!activeButton && mobileTabButtons.length > 0) {
+        activeButton = mobileTabButtons[0];
+        activeButton.classList.add('active');
+      }
+
+      if (activeButton) {
+        activateMobilePanel(activeButton.dataset.target);
+      }
+    }
+
+    mobileTabButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        if (!mobileMediaQuery.matches) {
+          return;
+        }
+
+        if (button.classList.contains('active')) {
+          return;
+        }
+
+        activateMobilePanel(button.dataset.target);
+      });
+    });
+
+    if (typeof mobileMediaQuery.addEventListener === 'function') {
+      mobileMediaQuery.addEventListener('change', syncMobilePanelsForViewport);
+    } else if (typeof mobileMediaQuery.addListener === 'function') {
+      mobileMediaQuery.addListener(syncMobilePanelsForViewport);
+    }
+
+    syncMobilePanelsForViewport();
+  }
+
   updateUI();
 });
 

--- a/style.css
+++ b/style.css
@@ -164,6 +164,34 @@ button:hover {
   /*padding-left: calc(1rem + 8px);  /* shift content over so it’s not on top */
 }
 
+#poop-mobile-tabs {
+  display: none;
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+}
+
+#poop-mobile-tabs .poop-mobile-tab {
+  flex: 1;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  border-radius: 0.5rem;
+  background-color: rgba(76, 56, 45, 0.75);
+}
+
+#poop-mobile-tabs .poop-mobile-tab.active {
+  background-color: #5c443d;
+}
+
+#poop-mobile-panels {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+#poop-mobile-panels [data-mobile-panel] {
+  width: 100%;
+}
+
 .spot-capacity,
 .spot-occupants {
   font-size: 0.85rem;
@@ -342,6 +370,72 @@ button:hover {
 .upgrade-card button {
   margin-top: 0.5rem;
   align-self: stretch;
+}
+
+
+@media (max-width: 767px) {
+  #tab-poop {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "header"
+      "info"
+      "main"
+      "mobile-tabs"
+      "mobile-panels";
+  }
+
+  #poop-side-panel {
+    display: contents;
+    padding: 0;
+    border-left: none;
+    background: transparent;
+  }
+
+  #currencies-panel {
+    display: none;
+  }
+
+  #poop-mobile-tabs {
+    display: grid;
+    grid-area: mobile-tabs;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.5rem;
+    padding: 0 1rem 0.5rem;
+  }
+
+  #poop-mobile-tabs .poop-mobile-tab {
+    background-color: rgba(76, 56, 45, 0.9);
+  }
+
+  #poop-mobile-tabs .poop-mobile-tab.active {
+    background-color: #4e3629;
+  }
+
+  #poop-mobile-panels {
+    grid-area: mobile-panels;
+    background: #b4a98d;
+    border-radius: 0.75rem;
+    padding: 1rem;
+    gap: 0.75rem;
+  }
+
+  #poopers-panel {
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
+
+  #poop-mobile-panels [data-mobile-panel] {
+    display: none;
+  }
+
+  #poop-mobile-panels [data-mobile-panel].mobile-panel-active {
+    display: block;
+  }
+
+  #poop-mobile-panels [data-mobile-panel].mobile-panel-active.panel-section {
+    display: flex;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- wrap the Pooper hiring, list, and upgrades sections in a new #poop-mobile-panels container and add mobile tab buttons in the sidebar markup
- add responsive CSS that hides the desktop side panel under 768px, shows a mobile tab strip, and collapses the layout to a single column
- implement a lightweight mobile tab controller that toggles visibility of the existing panel sections when the viewport is below the breakpoint

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ccb0d7aee48326b6e053a5c1d78585