### PR TITLE
Revamp upgrade cards with expandable details

### DIFF
--- a/style.css
+++ b/style.css
@@ -333,20 +333,24 @@ button:hover {
   grid-area: upgrades;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   margin-bottom: 1rem;
-  }
+}
 
 .upgrade-card {
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 0.25rem;
-  padding: 0.75rem;
   background: #d9c7a1;
   border: 2px solid #4e3629;
   border-radius: 0.5rem;
+  overflow: hidden;
   text-align: left;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.upgrade-card:hover {
+  border-color: #36261d;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .upgrade-card.locked {
@@ -357,19 +361,107 @@ button:hover {
   opacity: 0.75;
 }
 
-.upgrade-card h4 {
-  margin: 0;
-  font-size: 1rem;
+.upgrade-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.85rem;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: background-color 0.2s ease;
 }
 
-.upgrade-card p {
+.upgrade-card[data-expanded="true"] .upgrade-summary {
+  background-color: rgba(76, 56, 45, 0.15);
+}
+
+.upgrade-name {
+  flex: 1;
+}
+
+.upgrade-cost {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.9rem;
+}
+
+.upgrade-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 50%;
+  border: 1px solid #4e3629;
+  background-color: transparent;
+  color: #4e3629;
+  padding: 0;
+  font-weight: 700;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.upgrade-toggle:hover {
+  background-color: rgba(78, 54, 41, 0.15);
+}
+
+.upgrade-toggle:focus-visible {
+  outline: 2px solid #2f2119;
+  outline-offset: 2px;
+}
+
+.upgrade-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0 0.85rem;
+  max-height: 0;
+  opacity: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.25s ease, padding 0.3s ease;
+}
+
+.upgrade-card[data-expanded="true"] .upgrade-details {
+  padding: 0.6rem 0.85rem 0.85rem;
+  max-height: 600px;
+  opacity: 1;
+}
+
+.upgrade-description,
+.upgrade-status {
   margin: 0;
   font-size: 0.85rem;
 }
 
-.upgrade-card button {
-  margin-top: 0.5rem;
-  align-self: stretch;
+.upgrade-status {
+  font-weight: 600;
+}
+
+.upgrade-details button {
+  margin-top: 0.25rem;
+  align-self: flex-start;
+}
+
+@media (max-width: 600px) {
+  .upgrade-summary {
+    flex-wrap: wrap;
+    row-gap: 0.35rem;
+  }
+
+  .upgrade-name {
+    flex-basis: 100%;
+  }
+
+  .upgrade-cost {
+    margin-left: 0;
+  }
+
+  .upgrade-details {
+    font-size: 0.9rem;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- render each upgrade as a summary row with formatted cost, accessible toggle control, and expandable detail panel
- guard purchase interactions from detail toggles while keeping cost/status messaging inside the revealed section
- restyle upgrade cards into slim bars that animate open on desktop and mobile breakpoints

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ccbd36f2c48326a81b6b69c086db06