### PR TITLE
Revamp upgrade cards layout and interactions

### DIFF
--- a/style.css
+++ b/style.css
@@ -331,45 +331,188 @@ button:hover {
 
 #upgrades-panel {
   grid-area: upgrades;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 0.75rem;
   margin-bottom: 1rem;
+  align-content: start;
+}
+
+@media (min-width: 768px) {
+  #upgrades-panel {
+    grid-template-columns: repeat(3, minmax(160px, 1fr));
   }
+}
+
+@media (min-width: 1200px) {
+  #upgrades-panel {
+    grid-template-columns: repeat(4, minmax(160px, 1fr));
+  }
+}
 
 .upgrade-card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 0.25rem;
+  justify-content: space-between;
+  gap: 0.5rem;
+  min-height: 170px;
   padding: 0.75rem;
-  background: #d9c7a1;
+  background: #f0e1be;
   border: 2px solid #4e3629;
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
   text-align: left;
+  color: #2f2119;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease, opacity 0.2s ease;
+  cursor: pointer;
+  overflow: visible;
+}
+
+.upgrade-card:focus-visible {
+  outline: 2px solid #ffb347;
+  outline-offset: 2px;
+}
+
+.upgrade-card:hover:not(.locked),
+.upgrade-card:focus-visible:not(.locked) {
+  transform: translateY(-2px);
 }
 
 .upgrade-card.locked {
-  opacity: 0.6;
+  background: #d0d0d0;
+  border-color: #9a9a9a;
+  color: #666;
+  cursor: not-allowed;
+}
+
+.upgrade-card.locked::before {
+  content: "🔒";
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  font-size: 1.15rem;
 }
 
 .upgrade-card.purchased {
-  opacity: 0.75;
+  background: #cfe3cd;
+  border-color: #4e805a;
+  color: #2f4d2c;
+  opacity: 0.7;
+  cursor: default;
 }
 
-.upgrade-card h4 {
-  margin: 0;
-  font-size: 1rem;
+.upgrade-card.unaffordable {
+  opacity: 0.85;
 }
 
-.upgrade-card p {
-  margin: 0;
-  font-size: 0.85rem;
+.upgrade-card.affordable {
+  border-color: #ffb347;
+  box-shadow: 0 0 0.75rem rgba(255, 196, 0, 0.45);
 }
 
-.upgrade-card button {
-  margin-top: 0.5rem;
-  align-self: stretch;
+.upgrade-card.affordable:hover,
+.upgrade-card.affordable:focus-visible {
+  box-shadow: 0 0 1rem rgba(255, 196, 0, 0.6);
+}
+
+.upgrade-card::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.5rem);
+  transform: translate(-50%, 0);
+  width: max(160px, min(220px, 80vw));
+  padding: 0.55rem 0.65rem;
+  border-radius: 0.5rem;
+  background: rgba(47, 33, 25, 0.95);
+  color: #fff;
+  font-size: 0.75rem;
+  line-height: 1.3;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 10;
+}
+
+.upgrade-card:hover::after,
+.upgrade-card:focus-visible::after,
+.upgrade-card:focus-within::after {
+  opacity: 1;
+  transform: translate(-50%, -0.25rem);
+}
+
+.upgrade-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+}
+
+.upgrade-icon {
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.upgrade-name {
+  font-weight: 700;
+  font-size: 0.9rem;
+  line-height: 1.2;
+}
+
+.upgrade-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.upgrade-cost {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  background: rgba(78, 54, 41, 0.12);
+  border-radius: 0.5rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.upgrade-cost-value {
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.upgrade-card .upgrade-buy {
+  width: 100%;
+  margin-top: auto;
+  font-size: 0.8rem;
+  padding: 0.45rem 0.5rem;
+  border-radius: 999px;
+}
+
+.upgrade-card .upgrade-buy:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.upgrade-buy-denied {
+  animation: upgrade-denied 0.4s ease;
+}
+
+@keyframes upgrade-denied {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-4px);
+  }
+  75% {
+    transform: translateX(4px);
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- redesign the upgrade cards into compact icon-forward tiles with tooltip descriptions
- add responsive grid behavior with stateful styling for locked, unaffordable, and affordable upgrades
- hook upgrade buttons to allow hover tooltips and denial animation when resources are insufficient

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc7b4492c83269a78e1980523c58e