### PR TITLE
Refine poop tab layout and visual polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,19 +33,28 @@
         </div>
 
         <!-- poop main poop counter + defecate button -->
-        <div class="poop-info">
-          <h2>poop:</h2>
-          <p class="poop"></p>
-            <div class="poopIcon">💩</div>
-            <div id="poopAmount">0</div>
-            <div id="poopPerSecond">poop/second: 0</div>
-          <button id="defecatebutton">defecate</button>
-        </div>
-  
-        <!-- main grid -->
         <div class="poop-main">
-          <div id="spaces-grid">
-          </div>
+          <section class="poop-focus-card" aria-labelledby="poop-focus-heading">
+            <div class="poop-info">
+              <h2 id="poop-focus-heading">Poop Reserve</h2>
+              <div class="poop-totals">
+                <div class="poopIcon" aria-hidden="true">💩</div>
+                <div class="poop-counts">
+                  <div id="poopAmount" class="poop-amount">0</div>
+                  <div id="poopPerSecond" class="poop-per-second">poop/second: 0</div>
+                </div>
+              </div>
+              <button id="defecatebutton" class="primary-action">Defecate</button>
+            </div>
+          </section>
+
+          <section class="plot-section" aria-labelledby="empty-plots-heading">
+            <div class="section-heading">
+              <h3 id="empty-plots-heading">Empty Plots</h3>
+              <p>Invest in new restrooms to keep the poop flowing.</p>
+            </div>
+            <div id="spaces-grid" class="plot-grid"></div>
+          </section>
         </div>
         <!-- A.h: side panel -->
         <aside id="poop-side-panel">
@@ -87,39 +96,51 @@
               Upgrades
             </button>
           </nav>
-          <div id="poop-mobile-panels">
-            <div id="poopers-panel">
+          <div id="poop-mobile-panels" data-accordion-group>
+            <details class="panel-accordion-item" data-accordion-item open>
+              <summary class="panel-heading accordion-summary">
+                <span>Pooper Hiring</span>
+              </summary>
               <div
                 id="pooper-hiring"
-                class="panel-section mobile-panel-active"
+                class="panel-section accordion-content mobile-panel-active"
                 data-mobile-panel
                 role="tabpanel"
                 aria-labelledby="poop-mobile-tab-hiring"
               >
-                <h3 class="panel-heading">Pooper Hiring</h3>
                 <!-- list of pooper types + available/total + buy button -->
               </div>
+            </details>
+            <details class="panel-accordion-item" data-accordion-item>
+              <summary class="panel-heading accordion-summary">
+                <span>Pooper List</span>
+              </summary>
               <section
                 id="pooper-list-section"
-                class="panel-section"
+                class="panel-section accordion-content"
                 data-mobile-panel
                 role="tabpanel"
                 aria-labelledby="poop-mobile-tab-list"
               >
-                <h3 class="panel-heading">Pooper List</h3>
                 <div id="pooper-list-body" class="pooper-list" role="list">
                   <!-- dynamically populated -->
                 </div>
               </section>
-            </div>
-            <div
-              id="upgrades-panel"
-              data-mobile-panel
-              role="tabpanel"
-              aria-labelledby="poop-mobile-tab-upgrades"
-            >
-              <!-- upgrade icons (locked until milestones) -->
-            </div>
+            </details>
+            <details class="panel-accordion-item" data-accordion-item>
+              <summary class="panel-heading accordion-summary">
+                <span>Upgrades</span>
+              </summary>
+              <div
+                id="upgrades-panel"
+                class="accordion-content"
+                data-mobile-panel
+                role="tabpanel"
+                aria-labelledby="poop-mobile-tab-upgrades"
+              >
+                <!-- upgrade icons (locked until milestones) -->
+              </div>
+            </details>
           </div>
         </aside>
       </div>

--- a/style.css
+++ b/style.css
@@ -8,16 +8,49 @@ body {
 
 button {
   background-color: #7b5e57;
-  color: white;
+  color: #fff;
   border: none;
-  padding: 0.4rem 0.8rem; 
-  font-size: 0.85rem;       
-  border-radius: 0.25rem;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.95rem;
+  border-radius: 0.65rem;
   cursor: pointer;
+  font-weight: 600;
+  box-shadow: 0 6px 14px rgba(78, 54, 41, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    opacity 0.2s ease;
 }
 
-button:hover {
+button:hover:not(:disabled) {
   background-color: #5c443d;
+  transform: translateY(-2px);
+  box-shadow: 0 12px 24px rgba(78, 54, 41, 0.25);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: 0 6px 14px rgba(78, 54, 41, 0.25);
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary-action {
+  font-size: clamp(1.25rem, 4.5vw, 1.8rem);
+  padding: 1rem 2.25rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.card-button {
+  width: 100%;
+  justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
 
@@ -71,14 +104,12 @@ button:hover {
 /* Poop tab panels */
 #tab-poop {
   display: grid;
-  grid-template-columns: 1fr 300px;
+  grid-template-columns: minmax(0, 1fr) 360px;
   grid-template-rows:
-    auto     /* poop progress bar (poop-header) */
-    auto     /* poop icon + amount (poop-info) */
-    1fr;     /* spaces grid + side panel */
+    auto
+    1fr;
   grid-template-areas:
     "header side"
-    "info   side"
     "main   side";
   gap: 0;
   overflow: visible;
@@ -101,67 +132,138 @@ button:hover {
   transition: width 0.3s ease;
 }
 /* main + sidebar */
-/* Poop info */
+.poop-main {
+  grid-area: main;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: center;
+  padding: 1.5rem clamp(1rem, 3vw, 2.5rem) 2.25rem;
+  overflow-y: auto;
+}
+
+.poop-focus-card {
+  position: relative;
+  width: min(100%, 520px);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(255, 240, 215, 0.85));
+  border-radius: 1.75rem;
+  padding: clamp(1.75rem, 4vw, 2.5rem);
+  box-shadow: 0 24px 45px rgba(78, 54, 41, 0.25);
+  border: 1px solid rgba(78, 54, 41, 0.1);
+  overflow: visible;
+}
+
 .poop-info {
-  grid-area: info;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   text-align: center;
-  gap: 1rem;
-  padding: 1.25rem 1.5rem;
-  width: min(100%, 420px);
-  margin: 0 auto;
+  gap: 1.75rem;
+  position: relative;
 }
+
+.poop-info h2 {
+  font-size: clamp(1.35rem, 3.5vw, 1.8rem);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.poop-totals {
+  display: flex;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 1.75rem);
+}
+
 .poopIcon {
-  font-size: clamp(3rem, 8vw, 4.5rem);
+  font-size: clamp(3.25rem, 8vw, 5.25rem);
   line-height: 1;
   min-height: 3.5rem;
+  transition: transform 0.3s ease;
 }
-#poopAmount {
-  font-size: clamp(2.25rem, 7vw, 3.5rem);
+
+.poopIcon.poop-bounce {
+  animation: poopBounce 0.45s ease;
+}
+
+.poop-particle {
+  position: absolute;
+  bottom: calc(100% - 0.25rem);
+  left: 50%;
+  transform: translateX(calc(-50% + var(--x-offset, 0px)));
+  font-size: 1.05rem;
   font-weight: 700;
+  color: #7b5e57;
+  opacity: 0;
+  pointer-events: none;
+  filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.25));
+  animation: poopParticle 0.8s ease-out forwards;
 }
+
+.poop-counts {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+#poopAmount {
+  font-size: clamp(2.8rem, 8vw, 3.9rem);
+  font-weight: 800;
+}
+
 #poopPerSecond {
-  font-size: clamp(1.15rem, 4.5vw, 1.75rem);
+  font-size: clamp(1.35rem, 4.5vw, 2.1rem);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
-#defecatebutton {
-  font-size: clamp(1.2rem, 4.5vw, 1.6rem);
-  padding: 0.9rem 1.75rem;
-  min-height: 3.25rem;
-  width: 100%;
-  max-width: 360px;
-  border-radius: 999px;
-  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.15);
+
+.poop-per-second {
+  color: #3c2920;
 }
-@media (min-width: 768px) {
-  #defecatebutton {
-    width: auto;
-    min-width: 260px;
-  }
+
+.plot-section {
+  width: min(100%, 760px);
+  background: rgba(255, 248, 232, 0.95);
+  border-radius: 1.5rem;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  box-shadow: 0 16px 32px rgba(78, 54, 41, 0.2);
+  border: 1px solid rgba(78, 54, 41, 0.12);
 }
-.poop-main {
-  grid-area: main;
-  padding: 1rem;
-  overflow: auto;
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: center;
+  margin-bottom: 1.25rem;
+}
+
+.section-heading h3 {
+  margin: 0;
+  font-size: clamp(1.1rem, 3vw, 1.35rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-heading p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(60, 41, 32, 0.8);
 }
 /* side panels */
 #poop-side-panel {
   grid-area: side;
-  grid-template-rows:
-  auto    /* poop progress bar (poop-header) */
-  auto     /* poop icon + amount (poop-info) */
-  1fr;     /* spaces grid + side panel */
-  grid-template-areas:
-  "currencies""
-  "poopers""
-  "upgrades";
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
   background: #b4a98d;
-  padding: 1rem;
-  overflow: auto;
-  border-left: thick double #4d382d;  /* thick poop-brown bar */
-  /*padding-left: calc(1rem + 8px);  /* shift content over so it’s not on top */
+  padding: 1.5rem 1.25rem 1.75rem;
+  overflow-y: auto;
+  border-left: 12px solid #4d382d;
+  min-width: 340px;
 }
 
 #poop-mobile-tabs {
@@ -190,6 +292,62 @@ button:hover {
 
 #poop-mobile-panels [data-mobile-panel] {
   width: 100%;
+}
+
+.panel-accordion-item {
+  border-radius: 1rem;
+  background: rgba(255, 248, 232, 0.8);
+  border: 1px solid rgba(78, 54, 41, 0.2);
+  box-shadow: 0 10px 20px rgba(78, 54, 41, 0.18);
+  overflow: hidden;
+}
+
+.panel-accordion-item + .panel-accordion-item {
+  margin-top: 0.5rem;
+}
+
+.panel-accordion-item[open] {
+  background: rgba(255, 248, 232, 0.95);
+}
+
+.panel-heading {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 500;
+}
+
+.accordion-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1.1rem;
+  cursor: pointer;
+  list-style: none;
+}
+
+.accordion-summary::-webkit-details-marker {
+  display: none;
+}
+
+.accordion-summary::after {
+  content: "\25BC";
+  font-size: 0.75rem;
+  transition: transform 0.2s ease;
+}
+
+.panel-accordion-item[open] > .accordion-summary {
+  background: rgba(78, 54, 41, 0.1);
+}
+
+.panel-accordion-item[open] > .accordion-summary::after {
+  transform: rotate(-180deg);
+}
+
+.accordion-content {
+  padding: 1rem 1.1rem 1.25rem;
 }
 
 .spot-capacity,
@@ -293,13 +451,22 @@ button:hover {
 }
 
 .pooper-state {
-  font-size: 0.75rem;
-  padding: 0.15rem 0.45rem;
-  background: #7b5e57;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.6rem;
+  background: rgba(123, 94, 87, 0.85);
   color: #fff;
   border-radius: 999px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+.pooper-state-icon {
+  font-size: 1rem;
+  line-height: 1;
 }
 
 .pooper-progress-wrapper {
@@ -340,35 +507,66 @@ button:hover {
 .upgrade-card {
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  gap: 0.25rem;
-  padding: 0.75rem;
-  background: #d9c7a1;
-  border: 2px solid #4e3629;
-  border-radius: 0.5rem;
+  gap: 0.75rem;
+  padding: 1.1rem 1.25rem 1.35rem;
+  background: #f3e3c3;
+  border: 1px solid rgba(78, 54, 41, 0.2);
+  border-radius: 1rem;
   text-align: left;
+  box-shadow: 0 12px 26px rgba(78, 54, 41, 0.2);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .upgrade-card.locked {
-  opacity: 0.6;
+  opacity: 0.65;
+  filter: saturate(0.85);
 }
 
 .upgrade-card.purchased {
-  opacity: 0.75;
+  opacity: 0.8;
 }
 
-.upgrade-card h4 {
-  margin: 0;
-  font-size: 1rem;
+.upgrade-card:hover:not(.locked) {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 34px rgba(78, 54, 41, 0.24);
 }
 
-.upgrade-card p {
+.upgrade-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.upgrade-icon {
+  font-size: 1.7rem;
+}
+
+.upgrade-title {
   margin: 0;
-  font-size: 0.85rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.upgrade-description,
+.upgrade-cost,
+.upgrade-status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(60, 41, 32, 0.85);
+}
+
+.upgrade-status {
+  font-weight: 600;
+}
+
+.upgrade-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
 }
 
 .upgrade-card button {
-  margin-top: 0.5rem;
+  margin-top: auto;
   align-self: stretch;
 }
 
@@ -378,7 +576,6 @@ button:hover {
     grid-template-columns: 1fr;
     grid-template-areas:
       "header"
-      "info"
       "main"
       "mobile-tabs"
       "mobile-panels";
@@ -389,6 +586,15 @@ button:hover {
     padding: 0;
     border-left: none;
     background: transparent;
+  }
+
+  .poop-main {
+    padding: 1.25rem 1rem 2rem;
+  }
+
+  .poop-focus-card,
+  .plot-section {
+    width: 100%;
   }
 
   #currencies-panel {
@@ -419,10 +625,18 @@ button:hover {
     gap: 0.75rem;
   }
 
-  #poopers-panel {
-    border-bottom: none;
-    padding-bottom: 0;
-    margin-bottom: 0;
+  .panel-accordion-item {
+    border: none;
+    box-shadow: none;
+    background: transparent;
+  }
+
+  .accordion-summary {
+    display: none;
+  }
+
+  .accordion-content {
+    padding: 0;
   }
 
   #poop-mobile-panels [data-mobile-panel] {
@@ -445,48 +659,115 @@ button:hover {
 }
 #spaces-grid {
   display: grid;
-  grid-template-columns: repeat(10, 1fr);
-  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
 }
+
 .space-item {
-  display: flex;
-  flex-direction: column;      /* stack children vertically */
-  align-items: center;         /* center horizontally */
-  justify-content: center;     /* center vertically */
-  width: 64px; height: 64px;   /* adjust slot size */
-  margin: 0.5rem;
-  border: 2px dashed #aaa;     /* empty slot outline */
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.25rem 1.35rem 1.4rem;
+  border-radius: 1.25rem;
+  background: #f8edd1;
+  box-shadow: 0 12px 26px rgba(78, 54, 41, 0.18);
+  border: 1px solid rgba(78, 54, 41, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    background-color 0.2s ease;
 }
-.space-item button {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
-  cursor: pointer;
+
+.space-item:hover:not(.locked) {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 34px rgba(78, 54, 41, 0.22);
 }
+
+.space-item.locked {
+  background: #ebe0c4;
+  border-color: rgba(78, 54, 41, 0.15);
+  box-shadow: none;
+  opacity: 0.7;
+}
+
+.space-item.owned {
+  border-color: rgba(76, 128, 98, 0.55);
+  box-shadow: 0 20px 36px rgba(76, 128, 98, 0.28);
+}
+
+.plot-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.plot-icon {
+  font-size: 1.8rem;
+}
+
+.plot-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.plot-header-text h4 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.plot-header-text span {
+  font-size: 0.85rem;
+  color: rgba(60, 41, 32, 0.75);
+}
+
 .spot-info {
-  font-size: 0.7rem;
-  text-align: center;
-  margin-bottom: 0.35rem;
-  line-height: 1.2;
+  font-size: 0.9rem;
+  text-align: left;
+  line-height: 1.35;
 }
 
 .spot-info strong {
   display: block;
-  font-size: 0.8rem;
-  margin-bottom: 0.1rem;
+  font-size: 1.05rem;
+  margin-bottom: 0.35rem;
 }
 
-.spot-info div {
-  white-space: nowrap;
+.plot-progress-wrapper,
+.card-progress-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
 }
-.space-item button:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
+
+.card-progress,
+.plot-progress-bar {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(78, 54, 41, 0.2);
+  overflow: hidden;
 }
-.toilet-icon {
-  font-size: 1.5rem;            /* size of the 🚽 emoji */
-  margin-bottom: 0.25rem;       /* space between icon and button */
-  pointer-events: none;         /* clicks go through to the button */
+
+.card-progress-fill,
+.plot-progress-fill {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, #7b5e57, #4e3629);
+  width: 0%;
+  transition: width 0.3s ease;
+}
+
+.plot-progress-label,
+.card-progress-label {
+  font-size: 0.78rem;
+  color: rgba(60, 41, 32, 0.75);
+  text-align: right;
+}
+
+.plot-action {
+  margin-top: auto;
 }
 #building-menu {
   position: absolute;
@@ -521,4 +802,33 @@ button:hover {
 }
 #building-menu button:hover {
   background: #5a4444;
+}
+
+@keyframes poopBounce {
+  0% {
+    transform: scale(1);
+  }
+  25% {
+    transform: scale(1.12);
+  }
+  55% {
+    transform: scale(0.96);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes poopParticle {
+  0% {
+    opacity: 0;
+    transform: translateX(calc(-50% + var(--x-offset, 0px))) translateY(10px);
+  }
+  15% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: translateX(calc(-50% + var(--x-offset, 0px))) translateY(-38px);
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the poop tab with a central focus card and dedicated empty plot grid featuring progress indicators and consistent buy buttons
- convert the side panel into a single-open accordion and widen it on desktop while keeping mobile tab support
- refresh upgrade cards with icons, shadows, unlock progress bars, and add state icons plus bounce/particle feedback for poop gains

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccc7c57d1883269627dcf9b430311d