### PR TITLE
Polish poop info panel layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,12 +34,14 @@
 
         <!-- poop main poop counter + defecate button -->
         <div class="poop-info">
-          <h2>poop:</h2>
-          <p class="poop"></p>
+          <div class="poop-info-card">
+            <h2>poop:</h2>
+            <p class="poop"></p>
             <div class="poopIcon">💩</div>
             <div id="poopAmount">0</div>
             <div id="poopPerSecond">poop/second: 0</div>
-          <button id="defecatebutton">defecate</button>
+            <button id="defecatebutton">defecate</button>
+          </div>
         </div>
   
         <!-- main grid -->

--- a/style.css
+++ b/style.css
@@ -71,7 +71,7 @@ button:hover {
 /* Poop tab panels */
 #tab-poop {
   display: grid;
-  grid-template-columns: 1fr 300px;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 320px);
   grid-template-rows:
     auto     /* poop progress bar (poop-header) */
     auto     /* poop icon + amount (poop-info) */
@@ -80,7 +80,10 @@ button:hover {
     "header side"
     "info   side"
     "main   side";
-  gap: 0;
+  row-gap: clamp(1.5rem, 4vw, 3rem);
+  column-gap: clamp(1.5rem, 4vw, 3rem);
+  padding: clamp(1rem, 3vw, 2.5rem);
+  align-items: start;
   overflow: visible;
 }
 .poop-header {
@@ -105,14 +108,25 @@ button:hover {
 .poop-info {
   grid-area: info;
   display: flex;
+  justify-content: center;
+  align-items: stretch;
+  text-align: center;
+}
+
+.poop-info-card {
+  display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  text-align: center;
-  gap: 1rem;
-  padding: 1.25rem 1.5rem;
-  width: min(100%, 420px);
+  gap: clamp(1rem, 3vw, 1.75rem);
+  width: min(100%, 460px);
   margin: 0 auto;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  background: rgba(255, 251, 244, 0.9);
+  border-radius: 1.5rem;
+  box-shadow:
+    0 18px 35px -22px rgba(78, 54, 41, 0.7),
+    0 10px 25px -20px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(2px);
 }
 .poopIcon {
   font-size: clamp(3rem, 8vw, 4.5rem);
@@ -382,6 +396,9 @@ button:hover {
       "main"
       "mobile-tabs"
       "mobile-panels";
+    padding: 1rem;
+    row-gap: 1.5rem;
+    column-gap: 0;
   }
 
   #poop-side-panel {


### PR DESCRIPTION
## Summary
- wrap the poop tab's central stats in a dedicated card container in the markup
- restyle the new poop info card with padding, rounded corners, and a soft shadow
- adjust the poop tab grid spacing to add breathing room around the card while keeping mobile stacking clean

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccd734cd0c8326b39c4ac1f81e6b54