### PR TITLE
Restyle upgrade cards for compact grid layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,6 +63,7 @@ const upgrades = [
   {
     id: "upgrade1",
     name: "Poop Scooper",
+    icon: "🧹",
     description: "Make every defecate click more productive.",
     cost: 100,
     effect: () => {
@@ -74,6 +75,7 @@ const upgrades = [
   {
     id: "upgrade2",
     name: "Composting Bin",
+    icon: "♻️",
     description: "Generates a slow passive stream of poop.",
     cost: 500,
     effect: () => {
@@ -85,6 +87,7 @@ const upgrades = [
   {
     id: "upgrade3",
     name: "Super Poop Vacuum",
+    icon: "🌀",
     description: "Supercharge your workers' output.",
     cost: 2500,
     effect: () => {
@@ -101,6 +104,7 @@ const upgrades = [
   {
     id: "upgrade4",
     name: "Advanced Composting System",
+    icon: "🌿",
     description: "Massively increases passive generation and lowers hiring costs.",
     cost: 10000,
     effect: () => {
@@ -645,51 +649,55 @@ function renderUpgrades() {
 
     if (upgrade.isPurchased) {
       card.classList.add("purchased");
-    }
-
-    if (!upgrade.isUnlocked()) {
+    } else if (!upgrade.isUnlocked()) {
       card.classList.add("locked");
+    } else if (points < upgrade.cost) {
+      card.classList.add("unaffordable");
+    } else {
+      card.classList.add("affordable");
     }
 
-    const title = document.createElement("h4");
+    const header = document.createElement("div");
+    header.className = "upgrade-header";
+
+    const icon = document.createElement("span");
+    icon.className = "upgrade-icon";
+    icon.textContent = upgrade.icon || "✨";
+
+    const title = document.createElement("span");
+    title.className = "upgrade-name";
     title.textContent = upgrade.name;
 
-    const description = document.createElement("p");
-    description.className = "upgrade-description";
-    description.textContent = upgrade.description;
+    header.append(icon, title);
 
-    const cost = document.createElement("p");
+    const cost = document.createElement("div");
     cost.className = "upgrade-cost";
     cost.textContent = `Cost: ${formatNumber(upgrade.cost)}`;
 
-    const status = document.createElement("p");
-    status.className = "upgrade-status";
-    if (upgrade.isPurchased) {
-      status.textContent = "Purchased";
-    } else if (!upgrade.isUnlocked()) {
-      status.textContent = "Locked";
-    } else if (points < upgrade.cost) {
-      status.textContent = "Need more poop";
-    } else {
-      status.textContent = "Ready to purchase";
-    }
-
     const button = document.createElement("button");
     button.type = "button";
+    button.className = "upgrade-button";
 
     if (upgrade.isPurchased) {
-      button.textContent = "Purchased";
+      button.textContent = "Owned";
       button.disabled = true;
     } else if (!upgrade.isUnlocked()) {
       button.textContent = "Locked";
       button.disabled = true;
     } else {
-      button.textContent = `Buy (${formatNumber(upgrade.cost)})`;
-      button.disabled = points < upgrade.cost;
+      button.textContent = "Buy";
+      button.disabled = false;
       button.addEventListener("click", () => purchaseUpgrade(upgrade));
     }
 
-    card.append(title, description, cost, status, button);
+    const tooltip = document.createElement("div");
+    tooltip.className = "upgrade-tooltip";
+    tooltip.textContent = upgrade.description;
+    const tooltipId = `${upgrade.id}-tooltip`;
+    tooltip.id = tooltipId;
+    button.setAttribute("aria-describedby", tooltipId);
+
+    card.append(header, cost, button, tooltip);
     upgradesPanel.appendChild(card);
   });
 }

--- a/style.css
+++ b/style.css
@@ -331,45 +331,163 @@ button:hover {
 
 #upgrades-panel {
   grid-area: upgrades;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(90px, 1fr));
+  gap: 0.35rem;
   margin-bottom: 1rem;
+  position: relative;
+  overflow: visible;
+}
+
+@media (min-width: 768px) {
+  #upgrades-panel {
+    grid-template-columns: repeat(3, minmax(90px, 1fr));
   }
+}
+
+@media (min-width: 1200px) {
+  #upgrades-panel {
+    grid-template-columns: repeat(4, minmax(90px, 1fr));
+  }
+}
 
 .upgrade-card {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
+  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
   gap: 0.25rem;
-  padding: 0.75rem;
+  padding: 0.5rem;
+  min-height: 120px;
   background: #d9c7a1;
   border: 2px solid #4e3629;
   border-radius: 0.5rem;
   text-align: left;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+  overflow: visible;
+}
+
+.upgrade-card:hover:not(.locked) {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(78, 54, 41, 0.15);
 }
 
 .upgrade-card.locked {
-  opacity: 0.6;
+  background: #c9c9c9;
+  border-color: #8c8c8c;
+  color: #4a4a4a;
+}
+
+.upgrade-card.locked::after {
+  content: "🔒";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.75rem;
+  background: rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+}
+
+.upgrade-card.unaffordable {
+  opacity: 0.65;
+}
+
+.upgrade-card.affordable {
+  border-color: #ffb347;
+  box-shadow: 0 0 0 2px rgba(255, 179, 71, 0.25), 0 0 12px rgba(255, 179, 71, 0.45);
 }
 
 .upgrade-card.purchased {
-  opacity: 0.75;
+  opacity: 0.5;
 }
 
-.upgrade-card h4 {
-  margin: 0;
-  font-size: 1rem;
+.upgrade-header {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem;
+  align-items: center;
 }
 
-.upgrade-card p {
-  margin: 0;
-  font-size: 0.85rem;
+.upgrade-icon {
+  font-size: 1.15rem;
+  line-height: 1;
 }
 
-.upgrade-card button {
-  margin-top: 0.5rem;
-  align-self: stretch;
+.upgrade-name {
+  font-weight: 700;
+  font-size: 0.75rem;
+  line-height: 1.25;
+  color: #2f2119;
+}
+
+.upgrade-card.locked .upgrade-icon {
+  filter: grayscale(1);
+}
+
+.upgrade-card.purchased .upgrade-icon {
+  filter: grayscale(1);
+}
+
+.upgrade-cost {
+  font-size: 0.7rem;
+  margin-top: auto;
+  color: #3d2a20;
+}
+
+.upgrade-button {
+  font-size: 0.7rem;
+  padding: 0.35rem 0.45rem;
+  border-radius: 0.35rem;
+  align-self: end;
+  width: 100%;
+}
+
+.upgrade-card.locked .upgrade-button,
+.upgrade-card.purchased .upgrade-button {
+  cursor: not-allowed;
+}
+
+.upgrade-card.unaffordable .upgrade-button {
+  cursor: pointer;
+}
+
+.upgrade-tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translate(-50%, 0);
+  padding: 0.4rem 0.5rem;
+  border-radius: 0.4rem;
+  background: #4e3629;
+  color: #fff;
+  font-size: 0.7rem;
+  line-height: 1.3;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+  max-width: 220px;
+  width: max-content;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 10;
+}
+
+.upgrade-tooltip::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: #4e3629 transparent transparent transparent;
+}
+
+.upgrade-card:hover .upgrade-tooltip,
+.upgrade-card:focus-within .upgrade-tooltip {
+  opacity: 1;
+  transform: translate(-50%, -4px);
 }
 
 


### PR DESCRIPTION
## Summary
- shrink the upgrade cards into compact tiles that show an icon, name, and cost with tooltip descriptions
- lay out the upgrades in a responsive grid that shows 3 cards per row on medium screens and 4 on wide screens
- highlight card states for locked, unaffordable, and affordable upgrades to clarify interaction cues

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ccd4950b788326854861c914fd4b37