### PR TITLE
Refine upgrade cards layout and interactions

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,6 +63,7 @@ const upgrades = [
   {
     id: "upgrade1",
     name: "Poop Scooper",
+    icon: "🧹",
     description: "Make every defecate click more productive.",
     cost: 100,
     effect: () => {
@@ -74,6 +75,7 @@ const upgrades = [
   {
     id: "upgrade2",
     name: "Composting Bin",
+    icon: "🪱",
     description: "Generates a slow passive stream of poop.",
     cost: 500,
     effect: () => {
@@ -85,6 +87,7 @@ const upgrades = [
   {
     id: "upgrade3",
     name: "Super Poop Vacuum",
+    icon: "🌀",
     description: "Supercharge your workers' output.",
     cost: 2500,
     effect: () => {
@@ -101,6 +104,7 @@ const upgrades = [
   {
     id: "upgrade4",
     name: "Advanced Composting System",
+    icon: "♻️",
     description: "Massively increases passive generation and lowers hiring costs.",
     cost: 10000,
     effect: () => {
@@ -642,54 +646,67 @@ function renderUpgrades() {
   upgrades.forEach((upgrade) => {
     const card = document.createElement("div");
     card.className = "upgrade-card";
+    card.dataset.description = upgrade.description;
+    card.tabIndex = 0;
+    card.setAttribute("role", "group");
 
-    if (upgrade.isPurchased) {
+    const isUnlocked = upgrade.isUnlocked();
+    const isPurchased = upgrade.isPurchased;
+    const canAfford = points >= upgrade.cost;
+
+    if (isPurchased) {
       card.classList.add("purchased");
     }
 
-    if (!upgrade.isUnlocked()) {
+    if (!isUnlocked) {
       card.classList.add("locked");
+    } else if (!isPurchased && !canAfford) {
+      card.classList.add("unaffordable");
     }
 
-    const title = document.createElement("h4");
+    if (isUnlocked && !isPurchased && canAfford) {
+      card.classList.add("affordable");
+    }
+
+    const header = document.createElement("div");
+    header.className = "upgrade-card-header";
+
+    const icon = document.createElement("span");
+    icon.className = "upgrade-icon";
+    icon.textContent = upgrade.icon || "⬆️";
+
+    const title = document.createElement("span");
+    title.className = "upgrade-name";
     title.textContent = upgrade.name;
 
-    const description = document.createElement("p");
-    description.className = "upgrade-description";
-    description.textContent = upgrade.description;
+    header.append(icon, title);
 
-    const cost = document.createElement("p");
+    const spacer = document.createElement("div");
+    spacer.className = "upgrade-spacer";
+
+    const cost = document.createElement("div");
     cost.className = "upgrade-cost";
     cost.textContent = `Cost: ${formatNumber(upgrade.cost)}`;
 
-    const status = document.createElement("p");
-    status.className = "upgrade-status";
-    if (upgrade.isPurchased) {
-      status.textContent = "Purchased";
-    } else if (!upgrade.isUnlocked()) {
-      status.textContent = "Locked";
-    } else if (points < upgrade.cost) {
-      status.textContent = "Need more poop";
-    } else {
-      status.textContent = "Ready to purchase";
-    }
-
     const button = document.createElement("button");
     button.type = "button";
+    button.className = "upgrade-buy";
 
-    if (upgrade.isPurchased) {
+    if (isPurchased) {
       button.textContent = "Purchased";
       button.disabled = true;
-    } else if (!upgrade.isUnlocked()) {
+    } else if (!isUnlocked) {
       button.textContent = "Locked";
       button.disabled = true;
     } else {
       button.textContent = `Buy (${formatNumber(upgrade.cost)})`;
-      button.disabled = points < upgrade.cost;
+      if (!canAfford) {
+        button.classList.add("upgrade-buy--unaffordable");
+      }
       button.addEventListener("click", () => purchaseUpgrade(upgrade));
     }
 
-    card.append(title, description, cost, status, button);
+    card.append(header, spacer, cost, button);
     upgradesPanel.appendChild(card);
   });
 }

--- a/style.css
+++ b/style.css
@@ -331,45 +331,160 @@ button:hover {
 
 #upgrades-panel {
   grid-area: upgrades;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.5rem;
   margin-bottom: 1rem;
+  position: relative;
+  overflow: visible;
+}
+
+@media (min-width: 768px) {
+  #upgrades-panel {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
+}
+
+@media (min-width: 1200px) {
+  #upgrades-panel {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
 
 .upgrade-card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
+  align-items: flex-start;
   gap: 0.25rem;
-  padding: 0.75rem;
+  padding: 0.55rem;
   background: #d9c7a1;
   border: 2px solid #4e3629;
   border-radius: 0.5rem;
   text-align: left;
+  font-size: 0.75rem;
+  min-height: 112px;
+  aspect-ratio: 1 / 1;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.upgrade-card:focus-visible {
+  outline: 2px solid #7cb45a;
+  outline-offset: 2px;
+}
+
+.upgrade-card:hover {
+  transform: translateY(-1px);
+}
+
+.upgrade-card::after {
+  content: attr(data-description);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.5rem);
+  transform: translateX(-50%);
+  width: max-content;
+  max-width: 220px;
+  padding: 0.45rem 0.55rem;
+  border-radius: 0.45rem;
+  background: rgba(61, 46, 46, 0.95);
+  color: #fff;
+  font-size: 0.7rem;
+  line-height: 1.3;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 5;
+  text-align: left;
+}
+
+.upgrade-card:hover::after,
+.upgrade-card:focus-visible::after {
+  opacity: 1;
 }
 
 .upgrade-card.locked {
-  opacity: 0.6;
+  background: #bcbcbc;
+  border-color: #8a8a8a;
+  color: #444;
+}
+
+.upgrade-card.locked::before {
+  content: "🔒";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: rgba(0, 0, 0, 0.65);
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: inherit;
+  pointer-events: none;
 }
 
 .upgrade-card.purchased {
+  opacity: 0.65;
+}
+
+.upgrade-card.unaffordable {
   opacity: 0.75;
 }
 
-.upgrade-card h4 {
-  margin: 0;
-  font-size: 1rem;
+.upgrade-card.affordable {
+  border-color: #7cb45a;
+  box-shadow: 0 0 0.55rem rgba(124, 180, 90, 0.55);
 }
 
-.upgrade-card p {
-  margin: 0;
-  font-size: 0.85rem;
+.upgrade-card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 
-.upgrade-card button {
-  margin-top: 0.5rem;
-  align-self: stretch;
+.upgrade-icon {
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.upgrade-name {
+  font-weight: 700;
+  font-size: 0.78rem;
+  line-height: 1.1;
+}
+
+.upgrade-spacer {
+  flex: 1 1 auto;
+}
+
+.upgrade-cost {
+  width: 100%;
+  background: rgba(78, 54, 41, 0.18);
+  border-radius: 0.4rem;
+  padding: 0.25rem 0.35rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.upgrade-buy {
+  width: 100%;
+  margin-top: 0.35rem;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.7rem;
+  border-radius: 0.4rem;
+}
+
+.upgrade-buy--unaffordable {
+  background-color: #9a7f78;
+}
+
+.upgrade-card.locked .upgrade-buy,
+.upgrade-card.purchased .upgrade-buy {
+  background-color: #6f5c57;
+  cursor: not-allowed;
 }
 
 


### PR DESCRIPTION
## Summary
- restyle upgrade cards with icons, compact layout, and responsive grid sizing
- indicate locked, unaffordable, and affordable states with dedicated styling cues and tooltips for descriptions
- add card icons and streamline rendering logic to keep essential purchase controls at the bottom

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ccd4950b788326854861c914fd4b37