### PR TITLE
Implement accordion for poop management panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,37 +90,96 @@
             </button>
           </nav>
           <div id="poop-mobile-panels">
-            <div id="poopers-panel">
-              <div
-                id="pooper-hiring"
-                class="panel-section mobile-panel-active"
-                data-mobile-panel
-                role="tabpanel"
-                aria-labelledby="poop-mobile-tab-hiring"
-              >
-                <h3 class="panel-heading">Pooper Hiring</h3>
-                <!-- list of pooper types + available/total + buy button -->
-              </div>
-              <section
-                id="pooper-list-section"
-                class="panel-section"
-                data-mobile-panel
-                role="tabpanel"
-                aria-labelledby="poop-mobile-tab-list"
-              >
-                <h3 class="panel-heading">Pooper List</h3>
-                <div id="pooper-list-body" class="pooper-list" role="list">
-                  <!-- dynamically populated -->
+            <div id="poop-accordion" class="accordion" role="presentation">
+              <section class="accordion-item is-open" data-panel-id="pooper-hiring">
+                <h3 class="accordion-heading">
+                  <button
+                    type="button"
+                    class="accordion-trigger"
+                    data-accordion-target="pooper-hiring"
+                    aria-controls="pooper-hiring"
+                    aria-expanded="true"
+                    id="accordion-trigger-hiring"
+                  >
+                    <span class="accordion-title">Pooper Hiring</span>
+                  </button>
+                </h3>
+                <div class="accordion-content">
+                  <div class="accordion-content-inner">
+                    <div
+                      id="pooper-hiring"
+                      class="panel-section mobile-panel-active"
+                      data-mobile-panel
+                      role="tabpanel"
+                      aria-labelledby="poop-mobile-tab-hiring accordion-trigger-hiring"
+                      tabindex="0"
+                      aria-hidden="false"
+                    >
+                      <!-- list of pooper types + available/total + buy button -->
+                    </div>
+                  </div>
                 </div>
               </section>
-            </div>
-            <div
-              id="upgrades-panel"
-              data-mobile-panel
-              role="tabpanel"
-              aria-labelledby="poop-mobile-tab-upgrades"
-            >
-              <!-- upgrade icons (locked until milestones) -->
+              <section class="accordion-item" data-panel-id="pooper-list-section">
+                <h3 class="accordion-heading">
+                  <button
+                    type="button"
+                    class="accordion-trigger"
+                    data-accordion-target="pooper-list-section"
+                    aria-controls="pooper-list-section"
+                    aria-expanded="false"
+                    id="accordion-trigger-list"
+                  >
+                    <span class="accordion-title">Pooper List</span>
+                  </button>
+                </h3>
+                <div class="accordion-content">
+                  <div class="accordion-content-inner">
+                    <section
+                      id="pooper-list-section"
+                      class="panel-section"
+                      data-mobile-panel
+                      role="tabpanel"
+                      aria-labelledby="poop-mobile-tab-list accordion-trigger-list"
+                      tabindex="-1"
+                      aria-hidden="true"
+                    >
+                      <div id="pooper-list-body" class="pooper-list" role="list">
+                        <!-- dynamically populated -->
+                      </div>
+                    </section>
+                  </div>
+                </div>
+              </section>
+              <section class="accordion-item" data-panel-id="upgrades-panel">
+                <h3 class="accordion-heading">
+                  <button
+                    type="button"
+                    class="accordion-trigger"
+                    data-accordion-target="upgrades-panel"
+                    aria-controls="upgrades-panel"
+                    aria-expanded="false"
+                    id="accordion-trigger-upgrades"
+                  >
+                    <span class="accordion-title">Upgrades</span>
+                  </button>
+                </h3>
+                <div class="accordion-content">
+                  <div class="accordion-content-inner">
+                    <div
+                      id="upgrades-panel"
+                      class="panel-section"
+                      data-mobile-panel
+                      role="tabpanel"
+                      aria-labelledby="poop-mobile-tab-upgrades accordion-trigger-upgrades"
+                      tabindex="-1"
+                      aria-hidden="true"
+                    >
+                      <!-- upgrade icons (locked until milestones) -->
+                    </div>
+                  </div>
+                </div>
+              </section>
             </div>
           </div>
         </aside>

--- a/style.css
+++ b/style.css
@@ -226,14 +226,104 @@ button:hover {
   padding-bottom: calc(1rem + 8px);  /* shift content over so it’s not on top */
 } 
 
-#poopers-panel {
+#poop-accordion {
   grid-area: poopers;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   margin-bottom: 1rem;
   border-bottom: 8px solid #4e3629;  /* thick poop-brown bar */
-  padding-bottom: calc(1rem + 8px);  /* shift content over so it’s not on top */
+  padding-bottom: calc(1rem + 8px);
+}
+
+.accordion-item {
+  background: rgba(255, 251, 244, 0.9);
+  border: 1px solid #4e3629;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  box-shadow: 0 14px 24px -18px rgba(0, 0, 0, 0.55);
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.accordion-item.is-open {
+  border-color: #7b5e57;
+  box-shadow: 0 18px 30px -16px rgba(78, 54, 41, 0.65);
+  transform: translateY(-1px);
+}
+
+.accordion-heading {
+  margin: 0;
+}
+
+.accordion-trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  background: linear-gradient(135deg, rgba(124, 90, 66, 0.95), rgba(92, 68, 61, 0.95));
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border: none;
+  cursor: pointer;
+}
+
+.accordion-title {
+  flex: 1 1 auto;
+  text-align: left;
+}
+
+.accordion-item.is-open .accordion-trigger {
+  background: linear-gradient(135deg, rgba(124, 180, 90, 0.9), rgba(124, 180, 90, 0.75));
+  color: #3a2a20;
+}
+
+.accordion-trigger:focus-visible {
+  outline: 2px solid #f8d38b;
+  outline-offset: 3px;
+}
+
+.accordion-trigger::after {
+  content: "";
+  flex: none;
+  width: 0.75rem;
+  height: 0.75rem;
+  border: solid currentColor;
+  border-width: 0 0.15rem 0.15rem 0;
+  transform: rotate(45deg);
+  transition: transform 0.25s ease;
+}
+
+.accordion-item.is-open .accordion-trigger::after {
+  transform: rotate(225deg);
+}
+
+.accordion-content {
+  background: rgba(255, 251, 244, 0.88);
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.35s ease, opacity 0.35s ease;
+  opacity: 0;
+}
+
+.accordion-item.is-open .accordion-content {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.accordion-content-inner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.accordion-content-inner > [data-mobile-panel] {
+  padding: 1rem 1.1rem 1.25rem;
+  width: 100%;
+  min-height: 0;
 }
 
 .panel-section {
@@ -551,10 +641,23 @@ button:hover {
     gap: 0.75rem;
   }
 
-  #poopers-panel {
+  #poop-accordion {
     border-bottom: none;
     padding-bottom: 0;
-    margin-bottom: 0;
+    gap: 0.75rem;
+  }
+
+  .accordion-item {
+    border-radius: 0.65rem;
+  }
+
+  .accordion-trigger {
+    font-size: 0.95rem;
+    padding: 0.9rem 1rem;
+  }
+
+  .accordion-content-inner > [data-mobile-panel] {
+    padding: 0.75rem 0.75rem 1rem;
   }
 
   #poop-mobile-panels [data-mobile-panel] {
@@ -567,6 +670,20 @@ button:hover {
 
   #poop-mobile-panels [data-mobile-panel].mobile-panel-active.panel-section {
     display: flex;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .accordion-content {
+    transition: none;
+  }
+
+  .accordion-trigger::after {
+    transition: none;
+  }
+
+  .accordion-item {
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- wrap the hiring, pooper list, and upgrades sections in accordion markup tied to both mobile tabs and desktop controls
- style the new accordion with affordances, animations, and responsive tweaks that align with the existing sidebar presentation
- synchronize accordion and mobile tab state in script.js so only one panel is active at a time and hidden panels are inert

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ce0a5cff10832697b30b746d78be20