### PR TITLE
Style progress bar with themed overlay

### DIFF
--- a/script.js
+++ b/script.js
@@ -723,12 +723,27 @@ function purchaseUpgrade(upgrade) {
 }
 
 function updateProgressBar(current, max) {
+  const container = document.getElementById("poop-progress-container");
+  const progressBar = document.getElementById("poop-progress-bar");
 
-  const progressBar = document.getElementById('poop-progress-bar');
-  const percentage = (current / max) * 100;
+  if (!container || !progressBar) {
+    return;
+  }
+
+  const ratio = max > 0 ? current / max : 0;
+  const percentage = Math.max(0, Math.min(100, ratio * 100));
+
   progressBar.style.width = `${percentage}%`;
-  progressBar.textContent = `${formatNumber(current)} / ${formatNumber(max)}`;
-  console.log(`Progress: ${percentage}%`);
+  progressBar.textContent = "";
+
+  let label = container.querySelector(".poop-progress-label");
+  if (!label) {
+    label = document.createElement("span");
+    label.className = "poop-progress-label";
+    container.appendChild(label);
+  }
+
+  label.textContent = `${formatNumber(current)} / ${formatNumber(max)}`;
 }
 
 function getUnlockedSpaces() {

--- a/style.css
+++ b/style.css
@@ -91,17 +91,41 @@ button:hover {
   padding: 1rem;
 }
 #poop-progress-container {
+  position: relative;
   width: 100%;
-  height: 16px;
-  background: #ccc;
-  border-radius: 8px;
+  height: 20px;
+  background: linear-gradient(135deg, #5f3819, #a66f29);
+  border-radius: 999px;
   overflow: hidden;
+  box-shadow:
+    inset 0 2px 4px rgba(37, 21, 10, 0.55),
+    0 2px 6px rgba(82, 56, 33, 0.35);
+  border: 1px solid rgba(56, 30, 13, 0.5);
 }
 #poop-progress-bar {
   height: 100%;
   width: 0%;
-  background: #4caf50;
+  background: linear-gradient(135deg, #d9a441, #b8752a);
   transition: width 0.3s ease;
+  border-radius: inherit;
+}
+#poop-progress-container .poop-progress-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0 0.5rem;
+  color: #fff7d6;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.03em;
+  text-shadow: 0 1px 3px rgba(39, 21, 10, 0.85);
+  pointer-events: none;
+  white-space: nowrap;
 }
 /* main + sidebar */
 /* Poop info */


### PR DESCRIPTION
## Summary
- overlay a dedicated progress label span so the poop progress text stays centered regardless of bar fill
- restyle the poop progress container and bar with rounded gradients that match the poop theme and keep text readable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce3d2152a08326a5c78647ad9e0889