### PR TITLE
Shrink upgrade cards by 50%

### DIFF
--- a/style.css
+++ b/style.css
@@ -371,8 +371,8 @@ button:hover {
   grid-area: upgrades;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.5rem;
-  margin-bottom: 1rem;
+  gap: 0.35rem;
+  margin-bottom: 0.75rem;
   position: relative;
   overflow: visible;
 }
@@ -394,16 +394,16 @@ button:hover {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.25rem;
-  padding: 0.55rem;
+  gap: 0.125rem;
+  padding: 0.275rem;
   background: #d9c7a1;
-  border: 2px solid #4e3629;
-  border-radius: 0.5rem;
+  border: 1px solid #4e3629;
+  border-radius: 0.25rem;
   text-align: left;
-  font-size: 0.75rem;
-  min-height: 112px;
+  font-size: 0.375rem;
+  min-height: 56px;
   aspect-ratio: 1 / 1;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 0.5px 0 rgba(255, 255, 255, 0.35);
   transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
     opacity 0.15s ease;
 }
@@ -421,17 +421,17 @@ button:hover {
   content: attr(data-description);
   position: absolute;
   left: 50%;
-  bottom: calc(100% + 0.5rem);
+  bottom: calc(100% + 0.25rem);
   transform: translateX(-50%);
   width: max-content;
-  max-width: 220px;
-  padding: 0.45rem 0.55rem;
-  border-radius: 0.45rem;
+  max-width: 160px;
+  padding: 0.225rem 0.275rem;
+  border-radius: 0.225rem;
   background: rgba(61, 46, 46, 0.95);
   color: #fff;
-  font-size: 0.7rem;
+  font-size: 0.35rem;
   line-height: 1.3;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.15s ease;
@@ -457,7 +457,7 @@ button:hover {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 1.5rem;
+  font-size: 0.75rem;
   color: rgba(0, 0, 0, 0.65);
   background: rgba(255, 255, 255, 0.6);
   border-radius: inherit;
@@ -474,23 +474,23 @@ button:hover {
 
 .upgrade-card.affordable {
   border-color: #7cb45a;
-  box-shadow: 0 0 0.55rem rgba(124, 180, 90, 0.55);
+  box-shadow: 0 0 0.275rem rgba(124, 180, 90, 0.55);
 }
 
 .upgrade-card-header {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.175rem;
 }
 
 .upgrade-icon {
-  font-size: 1.2rem;
+  font-size: 0.6rem;
   line-height: 1;
 }
 
 .upgrade-name {
   font-weight: 700;
-  font-size: 0.78rem;
+  font-size: 0.39rem;
   line-height: 1.1;
 }
 
@@ -501,18 +501,18 @@ button:hover {
 .upgrade-cost {
   width: 100%;
   background: rgba(78, 54, 41, 0.18);
-  border-radius: 0.4rem;
-  padding: 0.25rem 0.35rem;
-  font-size: 0.7rem;
+  border-radius: 0.2rem;
+  padding: 0.125rem 0.175rem;
+  font-size: 0.35rem;
   font-weight: 600;
 }
 
 .upgrade-buy {
   width: 100%;
-  margin-top: 0.35rem;
-  padding: 0.35rem 0.5rem;
-  font-size: 0.7rem;
-  border-radius: 0.4rem;
+  margin-top: 0.175rem;
+  padding: 0.175rem 0.25rem;
+  font-size: 0.35rem;
+  border-radius: 0.2rem;
 }
 
 .upgrade-buy--unaffordable {


### PR DESCRIPTION
## Summary
- reduce the upgrade card footprint and spacing to make them half the original size
- scale down icon, text, buttons, tooltip, and locked overlay styling so card contents shrink proportionally

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce3e46b54c832694b5d08d59e7b150