### PR TITLE
Redesign spot UI strip and mobile panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,11 +44,15 @@
           </div>
         </div>
   
-        <!-- main grid -->
-        <div class="poop-main">
-          <div id="spaces-grid">
-          </div>
-        </div>
+        <!-- Spot strip -->
+        <section
+          id="spot-strip"
+          class="spot-strip"
+          role="list"
+          aria-label="Poop spots"
+        >
+          <!-- dynamically populated -->
+        </section>
         <!-- A.h: side panel -->
         <aside id="poop-side-panel">
           <div id="currencies-panel">
@@ -76,6 +80,17 @@
               aria-selected="false"
             >
               Pooper List
+            </button>
+            <button
+              type="button"
+              class="poop-mobile-tab"
+              data-target="spots-mobile-panel"
+              role="tab"
+              id="poop-mobile-tab-spots"
+              aria-controls="spots-mobile-panel"
+              aria-selected="false"
+            >
+              Spots
             </button>
             <button
               type="button"
@@ -114,6 +129,18 @@
                 </div>
               </section>
             </div>
+            <section
+              id="spots-mobile-panel"
+              class="panel-section"
+              data-mobile-panel
+              role="tabpanel"
+              aria-labelledby="poop-mobile-tab-spots"
+            >
+              <h3 class="panel-heading">Spots</h3>
+              <div id="spot-accordion" class="spot-accordion" role="list">
+                <!-- dynamically populated -->
+              </div>
+            </section>
             <div
               id="upgrades-panel"
               data-mobile-panel
@@ -133,8 +160,6 @@
       <div id="tab-terraform" class="tab-panel hidden"></div>
     </section>
     
-    <!-- Building menu (hidden by default) -->
-    <div id="building-menu" class="hidden"></div>
   </div>
 </body>
 <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -55,6 +55,7 @@ const spotRoster = [
 ];
 
 const spots = spotRoster.map(createSpotState);
+const spotViews = [];
 let averagePooperCost = 10;
 const aPoopers = [
   { name: "Average Pooper", rate: 1 }  // rate = poop/sec
@@ -162,20 +163,19 @@ const poopIcon           = document.querySelector(".poopIcon");
 const basePoopIconSize   = parseFloat(getComputedStyle(poopIcon).fontSize);
 const maxPoopForIconSize = 300000; // cap growth at 300k poop
 const defecateButton     = document.getElementById("defecatebutton");
-const spacesDisplay      = document.getElementById("spaces");
-const aPooperCostDisplay = document.getElementById("aPooperCost");
 const poopPerSecondDisplay = document.getElementById("poopPerSecond");
 const upgradesPanel      = document.getElementById("upgrades-panel");
 
 let pooperListContainer = null;
 
 
-//-------------------Spot grid------------------------
+//-------------------Spot strip------------------------
 document.addEventListener('DOMContentLoaded', () => {
   // Tab switching
   const tabs   = document.querySelectorAll('.tab-btn');
   const panels = document.querySelectorAll('.tab-panel');
-  const spacesGrid   = document.getElementById('spaces-grid');
+  const spotStrip   = document.getElementById('spot-strip');
+  const spotAccordion = document.getElementById('spot-accordion');
 
   tabs.forEach(btn => {
     btn.addEventListener('click', () => {
@@ -190,24 +190,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  if (spacesGrid) {
-    spacesGrid.innerHTML = '';
-    spots.forEach((spot, index) => {
-      const item = document.createElement('div');
-      item.className = 'space-item';
-      item.dataset.spotIndex = String(index);
+  if (spotStrip || spotAccordion) {
+    spots.forEach((_, index) => {
+      if (spotStrip) {
+        const card = createSpotCard(index);
+        spotStrip.appendChild(card);
+      }
 
-      const info = document.createElement('div');
-      info.className = 'spot-info';
-      item.appendChild(info);
-
-      const btn = document.createElement('button');
-      btn.type = 'button';
-      btn.dataset.spotIndex = String(index);
-      btn.addEventListener('click', () => upgradeSpot(index));
-      item.appendChild(btn);
-
-      spacesGrid.appendChild(item);
+      if (spotAccordion) {
+        const accordionItem = createSpotAccordionItem(index);
+        spotAccordion.appendChild(accordionItem);
+      }
     });
   }
 
@@ -238,7 +231,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const mobileTabsContainer = document.getElementById('poop-mobile-tabs');
-  const mobilePanelIds = ['pooper-hiring', 'pooper-list-section', 'upgrades-panel'];
+  const mobilePanelIds = ['pooper-hiring', 'pooper-list-section', 'spots-mobile-panel', 'upgrades-panel'];
   const mobilePanels = mobilePanelIds
     .map((panelId) => document.getElementById(panelId))
     .filter((panel) => panel);
@@ -520,6 +513,228 @@ function createSpotState(config) {
   return spot;
 }
 
+function ensureSpotView(index) {
+  if (!spotViews[index]) {
+    spotViews[index] = { renderedLevel: null };
+  }
+  return spotViews[index];
+}
+
+function createSpotCard(index) {
+  const view = ensureSpotView(index);
+  const card = document.createElement('article');
+  card.className = 'spot-card';
+  card.dataset.spotIndex = String(index);
+  card.setAttribute('role', 'listitem');
+
+  const body = document.createElement('div');
+  body.className = 'spot-card-body';
+
+  const icon = document.createElement('div');
+  icon.className = 'spot-icon';
+
+  const header = document.createElement('div');
+  header.className = 'spot-header';
+
+  const nameEl = document.createElement('h3');
+  nameEl.className = 'spot-name';
+
+  const levelBadge = document.createElement('span');
+  levelBadge.className = 'spot-level-badge';
+
+  header.append(nameEl, levelBadge);
+
+  const multiplier = document.createElement('div');
+  multiplier.className = 'spot-multiplier';
+
+  const occupancy = document.createElement('div');
+  occupancy.className = 'spot-occupancy';
+
+  const occupancyBar = document.createElement('div');
+  occupancyBar.className = 'spot-occupancy-bar';
+
+  const occupancyFill = document.createElement('div');
+  occupancyFill.className = 'spot-occupancy-fill';
+  occupancyBar.appendChild(occupancyFill);
+
+  const occupancyText = document.createElement('span');
+  occupancyText.className = 'spot-occupancy-text';
+  occupancy.append(occupancyBar, occupancyText);
+
+  const upgradeButton = document.createElement('button');
+  upgradeButton.type = 'button';
+  upgradeButton.className = 'spot-upgrade-button';
+  upgradeButton.addEventListener('click', () => upgradeSpot(index));
+
+  const tooltip = document.createElement('div');
+  tooltip.className = 'spot-tooltip';
+  tooltip.setAttribute('role', 'presentation');
+
+  const overlay = document.createElement('div');
+  overlay.className = 'spot-locked-overlay';
+
+  const overlayMessage = document.createElement('div');
+  overlayMessage.className = 'spot-locked-message';
+  overlay.appendChild(overlayMessage);
+
+  body.append(icon, header, multiplier, occupancy, upgradeButton);
+  card.append(body, overlay, tooltip);
+
+  view.card = {
+    element: card,
+    icon,
+    name: nameEl,
+    levelBadge,
+    multiplier,
+    occupancyFill,
+    occupancyText,
+    upgradeButton,
+    overlay,
+    overlayMessage,
+    tooltip,
+  };
+
+  return card;
+}
+
+function createSpotAccordionItem(index) {
+  const view = ensureSpotView(index);
+  const details = document.createElement('details');
+  details.className = 'spot-accordion-item';
+  details.dataset.spotIndex = String(index);
+  details.setAttribute('role', 'listitem');
+
+  const summary = document.createElement('summary');
+  summary.className = 'spot-accordion-summary';
+
+  const icon = document.createElement('span');
+  icon.className = 'spot-accordion-icon';
+
+  const nameEl = document.createElement('span');
+  nameEl.className = 'spot-accordion-name';
+
+  const level = document.createElement('span');
+  level.className = 'spot-accordion-level';
+
+  summary.append(icon, nameEl, level);
+
+  const body = document.createElement('div');
+  body.className = 'spot-accordion-body';
+
+  const multiplier = document.createElement('div');
+  multiplier.className = 'spot-accordion-multiplier';
+
+  const occupancy = document.createElement('div');
+  occupancy.className = 'spot-accordion-occupancy';
+
+  const tooltip = document.createElement('div');
+  tooltip.className = 'spot-accordion-tooltip';
+
+  const lockedMessage = document.createElement('div');
+  lockedMessage.className = 'spot-accordion-locked';
+
+  const upgradeButton = document.createElement('button');
+  upgradeButton.type = 'button';
+  upgradeButton.className = 'spot-upgrade-button';
+  upgradeButton.addEventListener('click', (event) => {
+    event.stopPropagation();
+    upgradeSpot(index);
+  });
+
+  body.append(multiplier, occupancy, tooltip, lockedMessage, upgradeButton);
+  details.append(summary, body);
+
+  view.accordion = {
+    element: details,
+    summary,
+    icon,
+    name: nameEl,
+    level,
+    multiplier,
+    occupancy,
+    tooltip,
+    locked: lockedMessage,
+    upgradeButton,
+  };
+
+  return details;
+}
+
+function updateSpotUpgradeButton(button, spot) {
+  if (!button) {
+    return;
+  }
+
+  button.classList.remove('is-locked', 'is-maxed', 'is-unaffordable');
+
+  if (!spot.isUnlocked) {
+    button.textContent = 'Locked';
+    button.disabled = true;
+    button.classList.add('is-locked');
+    return;
+  }
+
+  const cost = spot.nextUpgradeCost;
+
+  if (cost == null) {
+    button.textContent = 'Max Level';
+    button.disabled = true;
+    button.classList.add('is-maxed');
+    return;
+  }
+
+  const canAfford = points >= cost;
+  button.textContent = `Upgrade (${formatNumber(cost)})`;
+  button.disabled = !canAfford;
+
+  if (!canAfford) {
+    button.classList.add('is-unaffordable');
+  }
+}
+
+function createSpotTooltipMarkup(spot, tier, nextTier) {
+  const unlocked = spot.isUnlocked;
+  const capacityLabel = `${spot.capacity} seat${spot.capacity === 1 ? '' : 's'}`;
+  const bonusLabel = unlocked ? `x${spot.multiplier.toFixed(2)}` : '—';
+  const nextLabel = nextTier
+    ? `${nextTier.name} (x${nextTier.multiplier.toFixed(2)})`
+    : 'Maxed';
+  const upgradeCostLabel = spot.nextUpgradeCost != null
+    ? formatNumber(spot.nextUpgradeCost)
+    : '—';
+
+  return `
+    <dl class="spot-tooltip-list">
+      <div class="spot-tooltip-row"><dt>Tier</dt><dd>${unlocked ? tier.name : 'Locked'}</dd></div>
+      <div class="spot-tooltip-row"><dt>Capacity</dt><dd>${capacityLabel}</dd></div>
+      <div class="spot-tooltip-row"><dt>Occupancy</dt><dd>${spot.occupants.size} / ${spot.capacity}</dd></div>
+      <div class="spot-tooltip-row"><dt>Bonus</dt><dd>${bonusLabel}</dd></div>
+      <div class="spot-tooltip-row"><dt>Next Tier</dt><dd>${nextLabel}</dd></div>
+      <div class="spot-tooltip-row"><dt>Upgrade Cost</dt><dd>${upgradeCostLabel}</dd></div>
+      <div class="spot-tooltip-row"><dt>Unlock Rule</dt><dd>${formatNumber(spot.unlockAtTotal)} total poop</dd></div>
+    </dl>
+  `;
+}
+
+function triggerSpotLevelAnimation(element, className) {
+  if (!element) {
+    return;
+  }
+
+  element.classList.remove(className);
+  void element.offsetWidth;
+  element.classList.add(className);
+
+  if (element._spotLevelTimeout) {
+    clearTimeout(element._spotLevelTimeout);
+  }
+
+  element._spotLevelTimeout = setTimeout(() => {
+    element.classList.remove(className);
+    delete element._spotLevelTimeout;
+  }, 900);
+}
+
 function updateSpotUnlocks() {
   spots.forEach((spot) => {
     if (!spot.isUnlocked && totalPoints >= spot.unlockAtTotal) {
@@ -561,66 +776,142 @@ function upgradeSpot(index) {
   updateUI();
 }
 
-function updateSpotDisplay(index, slotElement) {
-  const items = document.querySelectorAll('#spaces-grid .space-item');
-  const slot = slotElement ?? items[index];
-
-  if (!slot) {
-    return;
-  }
-
-  let info = slot.querySelector('.spot-info');
-  if (!info) {
-    info = document.createElement('div');
-    info.className = 'spot-info';
-    slot.insertBefore(info, slot.firstChild ?? null);
-  }
-
+function updateSpotDisplay(index) {
   const spot = spots[index];
-  const btn = slot.querySelector('button');
-
   if (!spot) {
     return;
   }
 
-  const tier = getSpotTier(spot.level) || { icon: '', name: 'Spot' };
+  const view = ensureSpotView(index);
+  const tier = getSpotTier(spot.level) || spotTierConfig[0] || {
+    name: 'Spot',
+    icon: '❓',
+    multiplier: 1,
+  };
+  const nextTier = spotTierConfig[spot.level + 1] || null;
+  const iconSymbol = spot.isUnlocked ? (tier.icon || '❓') : '🔒';
+  const tooltipMarkup = createSpotTooltipMarkup(spot, tier, nextTier);
 
-  if (!spot.isUnlocked) {
-    const baseTier = getSpotTier(0) || tier;
-    info.innerHTML = `
-      <strong>${(baseTier && baseTier.icon) || ''} ${spot.name}</strong>
-      <div class="spot-locked">Locked</div>
-      <div>Unlocks at ${formatNumber(spot.unlockAtTotal)} total poop</div>
-    `;
-    if (btn) {
-      btn.textContent = 'Locked';
-      btn.disabled = true;
+  if (view?.card) {
+    const {
+      element,
+      icon,
+      name,
+      levelBadge,
+      multiplier,
+      occupancyFill,
+      occupancyText,
+      upgradeButton,
+      overlayMessage,
+      tooltip,
+    } = view.card;
+
+    element.classList.toggle('spot-card--locked', !spot.isUnlocked);
+
+    if (icon) {
+      icon.textContent = iconSymbol;
     }
-    return;
+
+    if (name) {
+      name.textContent = spot.name;
+    }
+
+    if (levelBadge) {
+      levelBadge.textContent = `Lv ${spot.level}`;
+    }
+
+    if (multiplier) {
+      multiplier.textContent = spot.isUnlocked
+        ? `Multiplier x${spot.multiplier.toFixed(2)}`
+        : 'Locked';
+    }
+
+    if (occupancyFill) {
+      const ratio = spot.capacity > 0
+        ? Math.min(1, spot.occupants.size / spot.capacity)
+        : 0;
+      occupancyFill.style.width = `${ratio * 100}%`;
+    }
+
+    if (occupancyText) {
+      occupancyText.textContent = `Occupancy: ${spot.occupants.size} / ${spot.capacity}`;
+    }
+
+    updateSpotUpgradeButton(upgradeButton, spot);
+
+    if (overlayMessage) {
+      overlayMessage.textContent = `Unlock at ${formatNumber(spot.unlockAtTotal)} total poop`;
+      overlayMessage.style.display = spot.isUnlocked ? 'none' : '';
+    }
+
+    if (tooltip) {
+      tooltip.innerHTML = tooltipMarkup;
+      tooltip.setAttribute('aria-hidden', spot.isUnlocked ? 'false' : 'true');
+    }
   }
 
-  const nextCost = spot.nextUpgradeCost;
-  const upgradeInfo = nextCost != null
-    ? `<div>Next Upgrade: ${formatNumber(nextCost)}</div>`
-    : '<div>Maxed Out</div>';
+  if (view?.accordion) {
+    const {
+      element,
+      icon,
+      name,
+      level,
+      multiplier,
+      occupancy,
+      tooltip,
+      locked,
+      upgradeButton,
+    } = view.accordion;
 
-  info.innerHTML = `
-    <strong>${(tier && tier.icon) || ''} ${spot.name}</strong>
-    <div>Tier: ${tier.name}</div>
-    <div>Level: ${spot.level}</div>
-    <div class="spot-occupants">Occupants: ${spot.occupants.size} / ${spot.capacity}</div>
-    <div>Multiplier: x${spot.multiplier.toFixed(2)}</div>
-    ${upgradeInfo}
-  `;
-
-  if (btn) {
-    if (nextCost == null) {
-      btn.textContent = 'Max Level';
-      btn.disabled = true;
-    } else {
-      btn.textContent = `Upgrade (${formatNumber(nextCost)})`;
-      btn.disabled = points < nextCost;
+    if (element) {
+      element.classList.toggle('spot-accordion-item--locked', !spot.isUnlocked);
     }
+
+    if (icon) {
+      icon.textContent = iconSymbol;
+    }
+
+    if (name) {
+      name.textContent = spot.name;
+    }
+
+    if (level) {
+      level.textContent = `Lv ${spot.level}`;
+    }
+
+    if (multiplier) {
+      multiplier.textContent = spot.isUnlocked
+        ? `Multiplier: x${spot.multiplier.toFixed(2)}`
+        : 'Multiplier: —';
+    }
+
+    if (occupancy) {
+      occupancy.textContent = `Occupancy: ${spot.occupants.size} / ${spot.capacity}`;
+    }
+
+    if (tooltip) {
+      tooltip.innerHTML = tooltipMarkup;
+    }
+
+    if (locked) {
+      locked.textContent = spot.isUnlocked ? '' : `Unlock at ${formatNumber(spot.unlockAtTotal)} total poop`;
+    }
+
+    updateSpotUpgradeButton(upgradeButton, spot);
+  }
+
+  if (view) {
+    if (view.renderedLevel != null && spot.level > view.renderedLevel) {
+      if (view.card?.element) {
+        triggerSpotLevelAnimation(view.card.element, 'spot-card--leveled');
+      }
+
+      if (view.accordion?.element) {
+        triggerSpotLevelAnimation(view.accordion.element, 'spot-accordion-item--leveled');
+      }
+    }
+
+    view.renderedLevel = spot.level;
   }
 }
 
@@ -914,11 +1205,7 @@ function updateUI() {
     pooperBuyButton.textContent = `Buy (${formatNumber(averagePooperCost)})`;
   }
 
-  const slots = document.querySelectorAll('#spaces-grid .space-item');
-  slots.forEach((slot, i) => {
-    slot.style.display = 'flex';
-    updateSpotDisplay(i, slot);
-  });
+  spots.forEach((_, index) => updateSpotDisplay(index));
   aPoopers.forEach((_, idx) => updatePooperCountDisplay(idx));
   updateProgressBar(totalPoints, 1e15);
   renderUpgrades();

--- a/style.css
+++ b/style.css
@@ -75,11 +75,11 @@ button:hover {
   grid-template-rows:
     auto     /* poop progress bar (poop-header) */
     auto     /* poop icon + amount (poop-info) */
-    1fr;     /* spaces grid + side panel */
+    minmax(0, 1fr); /* spot strip + side panel */
   grid-template-areas:
     "header side"
     "info   side"
-    "main   side";
+    "spots  side";
   row-gap: clamp(1.5rem, 4vw, 3rem);
   column-gap: clamp(1.5rem, 4vw, 3rem);
   padding: clamp(1rem, 3vw, 2.5rem);
@@ -179,27 +179,331 @@ button:hover {
     min-width: 260px;
   }
 }
-.poop-main {
-  grid-area: main;
-  padding: 1rem;
-  overflow: auto;
+#spot-strip {
+  grid-area: spots;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(220px, 1fr);
+  gap: clamp(1rem, 3vw, 1.75rem);
+  padding: 0 clamp(0.5rem, 3vw, 1.5rem) clamp(1.5rem, 4vw, 2.5rem);
+  margin-inline: calc(-1 * clamp(0.5rem, 3vw, 1.5rem));
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(78, 54, 41, 0.45) rgba(255, 255, 255, 0.4);
+  align-items: stretch;
+}
+
+#spot-strip::-webkit-scrollbar {
+  height: 0.6rem;
+}
+
+#spot-strip::-webkit-scrollbar-track {
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+}
+
+#spot-strip::-webkit-scrollbar-thumb {
+  background: rgba(78, 54, 41, 0.45);
+  border-radius: 999px;
+}
+
+.spot-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: clamp(1rem, 2.5vw, 1.35rem);
+  min-width: clamp(220px, 26vw, 280px);
+  background: linear-gradient(150deg, rgba(255, 249, 234, 0.95), rgba(225, 205, 162, 0.95));
+  border: 1px solid rgba(78, 54, 41, 0.25);
+  border-radius: 1.25rem;
+  box-shadow:
+    0 18px 35px -22px rgba(78, 54, 41, 0.6),
+    0 10px 25px -20px rgba(0, 0, 0, 0.3);
+  color: #3b2a1f;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.spot-card:hover,
+.spot-card:focus-within {
+  transform: translateY(-3px);
+  box-shadow:
+    0 20px 40px -20px rgba(78, 54, 41, 0.75),
+    0 16px 28px -20px rgba(0, 0, 0, 0.35);
+}
+
+.spot-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 100%;
+}
+
+.spot-icon {
+  width: 3.25rem;
+  height: 3.25rem;
+  display: grid;
+  place-items: center;
+  font-size: clamp(1.75rem, 3vw, 2.15rem);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.65);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.12);
+  align-self: flex-start;
+}
+
+.spot-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.spot-name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  text-align: left;
+}
+
+.spot-level-badge {
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  background: #7b5e57;
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.spot-multiplier {
+  font-size: 1rem;
+  font-weight: 700;
+  text-align: left;
+  color: #4e3629;
+}
+
+.spot-occupancy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: left;
+}
+
+.spot-occupancy-bar {
+  position: relative;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: rgba(78, 54, 41, 0.18);
+  overflow: hidden;
+}
+
+.spot-occupancy-fill {
+  height: 100%;
+  width: 0%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #7b5e57, #b08968);
+  transition: width 0.3s ease;
+}
+
+.spot-occupancy-text {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #3b2a1f;
+}
+
+.spot-upgrade-button {
+  margin-top: auto;
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.9rem;
+  border-radius: 0.75rem;
+  background: #7b5e57;
+  box-shadow: 0 6px 0 rgba(78, 54, 41, 0.35);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.spot-upgrade-button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 7px 0 rgba(78, 54, 41, 0.35);
+}
+
+.spot-upgrade-button:disabled {
+  opacity: 0.8;
+  cursor: not-allowed;
+}
+
+.spot-upgrade-button.is-unaffordable {
+  background: #9a7f78;
+}
+
+.spot-upgrade-button.is-maxed,
+.spot-upgrade-button.is-locked {
+  background: #6f5c57;
+  box-shadow: none;
+}
+
+.spot-card--locked {
+  color: #514032;
+}
+
+.spot-card--locked .spot-card-body {
+  filter: grayscale(0.25);
+  opacity: 0.85;
+}
+
+.spot-locked-overlay {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 1.1rem;
+  background: rgba(255, 254, 247, 0.88);
+  border-radius: inherit;
+  color: #4e3629;
+  font-weight: 600;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.spot-locked-message {
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.spot-locked-overlay span {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.spot-card--locked .spot-locked-overlay {
+  opacity: 1;
+}
+
+.spot-tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 0.5rem);
+  transform: translate(-50%, 10px);
+  width: clamp(220px, 24vw, 280px);
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 249, 234, 0.96);
+  border: 1px solid rgba(78, 54, 41, 0.25);
+  box-shadow: 0 12px 22px -14px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+  z-index: 8;
+}
+
+.spot-card:hover .spot-tooltip,
+.spot-card:focus-within .spot-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.spot-tooltip-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.spot-tooltip-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: #3b2a1f;
+}
+
+.spot-tooltip-row + .spot-tooltip-row {
+  margin-top: 0.25rem;
+}
+
+.spot-tooltip-row dt {
+  font-weight: 700;
+}
+
+.spot-tooltip-row dd {
+  margin: 0;
+}
+
+.spot-card--leveled {
+  animation: spotLevelGlow 0.9s ease-out;
+}
+
+.spot-card--leveled::after {
+  content: "";
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.9), transparent 55%),
+    radial-gradient(circle at 80% 30%, rgba(255, 221, 150, 0.7), transparent 60%),
+    radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.7), transparent 60%);
+  opacity: 0;
+  pointer-events: none;
+  animation: spotSparkle 0.9s ease-out;
+  mix-blend-mode: screen;
+}
+
+@keyframes spotLevelGlow {
+  0% {
+    box-shadow: 0 0 0 rgba(255, 223, 135, 0.9);
+  }
+  50% {
+    box-shadow: 0 0 22px rgba(255, 223, 135, 0.7);
+  }
+  100% {
+    box-shadow: 0 0 0 rgba(255, 223, 135, 0);
+  }
+}
+
+@keyframes spotSparkle {
+  0% {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  35% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spot-card--leveled {
+    animation: none;
+  }
+
+  .spot-card--leveled::after {
+    animation: none;
+    opacity: 0;
+  }
+
+  .spot-accordion-item--leveled {
+    animation: none;
+  }
 }
 /* side panels */
 #poop-side-panel {
   grid-area: side;
-  grid-template-rows:
-  auto    /* poop progress bar (poop-header) */
-  auto     /* poop icon + amount (poop-info) */
-  1fr;     /* spaces grid + side panel */
-  grid-template-areas:
-  "currencies""
-  "poopers""
-  "upgrades";
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   background: #b4a98d;
   padding: 1rem;
   overflow: auto;
   border-left: thick double #4d382d;  /* thick poop-brown bar */
-  /*padding-left: calc(1rem + 8px);  /* shift content over so it’s not on top */
 }
 
 #poop-mobile-tabs {
@@ -224,6 +528,127 @@ button:hover {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+#spots-mobile-panel {
+  display: none;
+}
+
+.spot-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spot-accordion-item {
+  position: relative;
+  border-radius: 1rem;
+  border: 1px solid rgba(78, 54, 41, 0.25);
+  background: rgba(255, 249, 234, 0.95);
+  overflow: hidden;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.spot-accordion-item[open] {
+  border-color: rgba(78, 54, 41, 0.45);
+  box-shadow: 0 14px 24px -18px rgba(0, 0, 0, 0.35);
+}
+
+.spot-accordion-item--locked {
+  opacity: 0.75;
+}
+
+.spot-accordion-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  cursor: pointer;
+  list-style: none;
+  font-weight: 600;
+}
+
+.spot-accordion-summary::-webkit-details-marker {
+  display: none;
+}
+
+.spot-accordion-summary::after {
+  content: "›";
+  margin-left: auto;
+  font-size: 1.1rem;
+  color: #7b5e57;
+  transform: rotate(90deg);
+  transition: transform 0.2s ease;
+}
+
+.spot-accordion-item[open] .spot-accordion-summary::after {
+  transform: rotate(-90deg);
+}
+
+.spot-accordion-icon {
+  font-size: 1.5rem;
+}
+
+.spot-accordion-name {
+  flex: 1;
+  text-align: left;
+}
+
+.spot-accordion-level {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  background: #7b5e57;
+  color: #fff;
+}
+
+.spot-accordion-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0 1rem 1rem 1rem;
+  font-size: 0.9rem;
+}
+
+.spot-accordion-multiplier,
+.spot-accordion-occupancy {
+  font-weight: 600;
+  color: #3b2a1f;
+}
+
+.spot-accordion-occupancy {
+  font-size: 0.85rem;
+}
+
+.spot-accordion-body .spot-upgrade-button {
+  margin-top: 0;
+}
+
+.spot-accordion-tooltip {
+  background: rgba(78, 54, 41, 0.08);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+}
+
+.spot-accordion-tooltip .spot-tooltip-list {
+  font-size: 0.8rem;
+}
+
+.spot-accordion-locked {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #4e3629;
+}
+
+.spot-accordion-locked:not(:empty) {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+}
+
+.spot-accordion-item--leveled {
+  animation: spotLevelGlow 0.9s ease-out;
 }
 
 #poop-mobile-panels [data-mobile-panel] {
@@ -532,7 +957,7 @@ button:hover {
     grid-template-areas:
       "header"
       "info"
-      "main"
+      "spots"
       "mobile-tabs"
       "mobile-panels";
     padding: 1rem;
@@ -547,6 +972,10 @@ button:hover {
     background: transparent;
   }
 
+  #spot-strip {
+    display: none;
+  }
+
   #currencies-panel {
     display: none;
   }
@@ -554,7 +983,7 @@ button:hover {
   #poop-mobile-tabs {
     display: grid;
     grid-area: mobile-tabs;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: 0.5rem;
     padding: 0 1rem 0.5rem;
   }
@@ -581,6 +1010,10 @@ button:hover {
     margin-bottom: 0;
   }
 
+  #spots-mobile-panel {
+    display: block;
+  }
+
   #poop-mobile-panels [data-mobile-panel] {
     display: none;
   }
@@ -592,89 +1025,10 @@ button:hover {
   #poop-mobile-panels [data-mobile-panel].mobile-panel-active.panel-section {
     display: flex;
   }
+
+  .spot-tooltip {
+    display: none;
+  }
 }
 
 
-/* Spaces grid */
-#spaces {
-  color: #666;
-}
-#spaces-grid {
-  display: grid;
-  grid-template-columns: repeat(10, 1fr);
-  gap: 0.5rem;
-}
-.space-item {
-  display: flex;
-  flex-direction: column;      /* stack children vertically */
-  align-items: center;         /* center horizontally */
-  justify-content: center;     /* center vertically */
-  width: 64px; height: 64px;   /* adjust slot size */
-  margin: 0.5rem;
-  border: 2px dashed #aaa;     /* empty slot outline */
-  position: relative;
-}
-.space-item button {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.75rem;
-  cursor: pointer;
-}
-.spot-info {
-  font-size: 0.7rem;
-  text-align: center;
-  margin-bottom: 0.35rem;
-  line-height: 1.2;
-}
-
-.spot-info strong {
-  display: block;
-  font-size: 0.8rem;
-  margin-bottom: 0.1rem;
-}
-
-.spot-info div {
-  white-space: nowrap;
-}
-.space-item button:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
-.toilet-icon {
-  font-size: 1.5rem;            /* size of the 🚽 emoji */
-  margin-bottom: 0.25rem;       /* space between icon and button */
-  pointer-events: none;         /* clicks go through to the button */
-}
-#building-menu {
-  position: absolute;
-  flex-direction: column;
-  background: #fff;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  padding: 0.5rem;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
-  z-index: 1000;
-}
-#building-menu button {
-  background: none;
-  border: none;
-  text-align: left;
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;    /* less padding */
-  font-size: 0.75rem;         /* smaller text */
-  border-radius: 0.2rem;      /* slightly smaller corners */
-  min-width: auto;
-  background: #3d2e2e;
-}
-#building-menu button .spot-name {
-  font-weight: 600;
-  display: block;
-}
-
-#building-menu button .spot-stats {
-  font-size: 0.7rem;
-  opacity: 0.85;
-  line-height: 1.3;
-}
-#building-menu button:hover {
-  background: #5a4444;
-}


### PR DESCRIPTION
## Summary
- replace the placeholder grid with a Spots strip and matching mobile tab entry
- restyle the poop tab to support the new spot cards, mobile accordion, tooltip, and level-up animation
- update spot rendering logic to drive the new UI, including upgrade state, tier icons, and tooltip content

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ceba7336d48326b2d2d92097185e29