### PR TITLE
Track pooper targets and sync occupancy UI

### DIFF
--- a/style.css
+++ b/style.css
@@ -768,6 +768,12 @@ button:hover {
   letter-spacing: 0.05em;
 }
 
+.pooper-detail {
+  font-size: 0.8rem;
+  color: #3b2a25;
+  opacity: 0.85;
+}
+
 .pooper-progress-wrapper {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- track each pooper's target spot and maintain waiting queues so spot occupancy stays in sync across transitions
- show a second line in the pooper list that calls out the worker's target or active spot with updated styling
- surface queued counts on spot cards, accordion rows, and tooltips to mirror the new targeting data

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68cec6c612f48326b7af06cffabfc459