### PR TITLE
Adjust baseline pacing and add MVP win modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,23 @@
     </section>
     
   </div>
+  <div
+    id="win-modal"
+    class="win-modal"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="win-modal-title"
+    hidden
+  >
+    <div class="win-modal__content" role="document">
+      <h2 id="win-modal-title">MVP Reached!</h2>
+      <p id="win-modal-message">You hit the MVP target!</p>
+      <div class="win-modal__actions">
+        <button id="win-dismiss-button" class="win-modal__button">Keep Playing</button>
+        <button id="win-replay-button" class="win-modal__button win-modal__button--accent">Restart Run</button>
+      </div>
+    </div>
+  </div>
 </body>
 <script src="script.js"></script>
 

--- a/style.css
+++ b/style.css
@@ -199,6 +199,68 @@ button:hover {
   height: 0.6rem;
 }
 
+.win-modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(54, 39, 28, 0.55);
+  backdrop-filter: blur(2px);
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.win-modal[hidden] {
+  display: none;
+}
+
+.win-modal__content {
+  background: #fff8e8;
+  color: #4e3629;
+  border-radius: 1rem;
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  box-shadow:
+    0 25px 45px -30px rgba(43, 28, 18, 0.7),
+    0 15px 35px -28px rgba(0, 0, 0, 0.45);
+  width: min(420px, 100%);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.win-modal__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 480px) {
+  .win-modal__actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+}
+
+.win-modal__button {
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  background: #7b5e57;
+  box-shadow: 0 4px 0 rgba(0, 0, 0, 0.15);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.win-modal__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 10px -6px rgba(0, 0, 0, 0.35);
+}
+
+.win-modal__button--accent {
+  background: #c77428;
+}
+
 #spot-strip::-webkit-scrollbar-track {
   background: rgba(255, 255, 255, 0.35);
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- expose pacing constants for clicks, pooper output, and spot upgrade costs to tune the 5–10 minute onboarding window
- adjust hire/upgrade scaling to use the new constants and centralize poop awards through an MVP-aware helper
- surface an MVP win modal with dismiss/restart affordances when the configured target is hit

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5ad24ae288326a0ce5cb32da4c30d